### PR TITLE
Upgrade docs, upgrade thyself

### DIFF
--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -1,7 +1,12 @@
-.. _upgrading_citus:
+.. _upgrading:
 
-Upgrading to Citus 5
-#######################
+Upgrading Citus
+$$$$$$$$$$$$$$$
+
+.. _upgrading_citus_major:
+
+Major Update from 4 to 5
+########################
 
 This section describes how you can upgrade your existing Citus installation to Citus 5.0.
 
@@ -163,3 +168,45 @@ At this step, you have successfully completed the upgrade process. You can run q
 **Running in a mixed mode**
 
 For users who don’t want to take a cluster down and upgrade all nodes at the same time, there is the possibility of running in a mixed 4.0 / 5.0 mode. To do so, you can first upgrade the master. Then, you can upgrade the workers one at a time. This way you can upgrade the cluster with no downtime. However, we recommend using 5.0 version in whole cluster.
+
+
+.. _upgrading_citus_minor:
+
+Minor Update from 5.0 to 5.1
+############################
+
+Upgrading requires first obtaining the new Citus extension and then installing it in each of your database instances. The first step varies by operating system.
+
+.. _upgrading_citus_minor_package:
+
+Step 1, Update Citus Package
+----------------------------
+
+**OS X**
+
+::
+
+  brew update
+  brew upgrade citus
+
+**Ubuntu or Debian**
+
+::
+
+  sudo apt-get update
+  sudo apt-get upgrade postgresql-9.5-citus
+
+**Fedora, CentOS, or Red Hat**
+
+::
+
+  sudo yum update citus_95
+
+.. _upgrading_citus_minor_extension:
+
+Step 2, Apply Update to DB
+--------------------------
+
+::
+
+  psql -c "ALTER EXTENSION citus UPDATE;"

--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -22,7 +22,7 @@ The others are known pg_upgrade manual steps, i.e. manually updating configurati
 
 We discuss the step by step process of upgrading the cluster below. Please note that you need to run the steps on all the nodes in the cluster. Some steps need to be run only on the master and they are explicitly marked as such.
 
-**1. Download and install Citus 5 on the server having the to-be-upgraded 4.0 data directory**
+**1. Download and install Citus 5**
 
 Follow the :ref:`installation instructions<requirements>` appropriate for your situation (e.g. single-machine or multi-machine). These instructions use the Citus package for your operating system, which includes PostgreSQL 9.5 as a dependency.
 
@@ -51,7 +51,7 @@ Please set appropriate values for data location like below. This makes accessing
 
 If you are upgrading the master, then you should stop all data-loading/appending and staging before copying out the metadata. If data-loading continues after step 4 below, then the metadata will be out of date.
 
-**4. Copy out pg_dist catalog metadata from the 4.0 server (Only needed for master)**
+**4. Copy out pg_dist catalog metadata from the Citus 4 server (Only needed for master)**
 ::
 
     COPY pg_dist_partition TO '/var/tmp/pg_dist_partition.data';
@@ -66,14 +66,14 @@ If you are upgrading the master, then you should stop all data-loading/appending
 
 This should return **Clusters are compatible**. If this doesn't return that message, you need to stop and check what the error is.
 
-Note: This may return the following warning if the 4.0 server has not been stopped. This warning is OK:
+Note: This may return the following warning if the Citus 4 server has not been stopped. This warning is OK:
 
 ::
 
     *failure*
     Consult the last few lines of "pg_upgrade_server.log" for the probable cause of the failure.
 
-**6. Shutdown the running 4.0 server**
+**6. Shutdown the running Citus 4 server**
 
 ::
 
@@ -151,12 +151,12 @@ You can ignore this error and continue with the process below.
 
 **15. Ready to run queries/create tables/load data**
  
-At this step, you have successfully completed the upgrade process. You can run queries, create new tables or add data to existing tables. Once everything looks good, the old 4.0 data directory can be deleted.
+At this step, you have successfully completed the upgrade process. You can run queries, create new tables or add data to existing tables. Once everything looks good, the old version 4 data directory can be deleted.
 
 
 **Running in a mixed mode**
 
-For users who don’t want to take a cluster down and upgrade all nodes at the same time, there is the possibility of running in a mixed 4.0 / 5.0 mode. To do so, you can first upgrade the master. Then, you can upgrade the workers one at a time. This way you can upgrade the cluster with no downtime. However, we recommend using 5.0 version in whole cluster.
+For users who don’t want to take a cluster down and upgrade all nodes at the same time, there is the possibility of running in a mixed version 4 / 5 mode. To do so, you can first upgrade the master. Then, you can upgrade the workers one at a time. This way you can upgrade the cluster with no downtime. However, we recommend using version five across the whole cluster.
 
 
 .. _upgrading_citus_minor:

--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -172,14 +172,14 @@ For users who don’t want to take a cluster down and upgrade all nodes at the s
 
 .. _upgrading_citus_minor:
 
-Minor Update from 5.0 to 5.1
-############################
+Minor Update to Latest 5.x
+##########################
 
 Upgrading requires first obtaining the new Citus extension and then installing it in each of your database instances. The first step varies by operating system.
 
 .. _upgrading_citus_minor_package:
 
-Step 1, Update Citus Package
+Step 1. Update Citus Package
 ----------------------------
 
 **OS X**
@@ -204,9 +204,15 @@ Step 1, Update Citus Package
 
 .. _upgrading_citus_minor_extension:
 
-Step 2, Apply Update to DB
+Step 2. Apply Update in DB
 --------------------------
+
+Restart PostgreSQL and run
 
 ::
 
+  # after restarting postgres
   psql -c "ALTER EXTENSION citus UPDATE;"
+
+  psql -c "\dx"
+  # you should see a newer Citus 5.x version in the list

--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -24,7 +24,7 @@ We discuss the step by step process of upgrading the cluster below. Please note 
 
 **1. Download and install Citus 5 on the server having the to-be-upgraded 4.0 data directory**
 
-Follow the :ref:`installation instructions<requirements>` appropriate for your situation (e.g. single-machine or multi-machine). These instructions use the Citus package for your operating system, and includes PostgreSQL 9.5 as a dependency.
+Follow the :ref:`installation instructions<requirements>` appropriate for your situation (e.g. single-machine or multi-machine). These instructions use the Citus package for your operating system, which includes PostgreSQL 9.5 as a dependency.
 
 .. note::
     The instructions below assume that the PostgreSQL installation is in your path. If not, you will need to add it to your PATH environment variable. For example:

--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -41,14 +41,15 @@ Please set appropriate values for data location like below. This makes accessing
 
 ::
 
+    # this location differs by operating system
     export PGDATA5=/usr/lib/postgresql/9.5/data
+
     export PGDATA4=/opt/citusdb/4.0/data
 
 
 **3. Stop loading data on to that instance**
 
-If you are upgrading the master, then you should stop all data-loading/appending
-and staging before copying out the metadata. If data-loading continues after step 4 below, then the metadata will be out of date.
+If you are upgrading the master, then you should stop all data-loading/appending and staging before copying out the metadata. If data-loading continues after step 4 below, then the metadata will be out of date.
 
 **4. Copy out pg_dist catalog metadata from the 4.0 server (Only needed for master)**
 ::

--- a/index.rst
+++ b/index.rst
@@ -47,6 +47,7 @@ topics.
    performance/performance_tuning.rst
 
 .. toctree::
+   :maxdepth: 1
    :caption: Administration
 
    admin_guide/cluster_management.rst


### PR DESCRIPTION
* These docs are currently written to upgrade to the newest 5.x version.
  * Another approach would be to pin the upgraded version to exactly 5.1 since these are destined to be 5.1 docs.
  * Pinning the version would mean this section of the docs needs to be updated to match the documentation version itself.
  * The instructions are also more cumbersome for pinning, especially with homebrew.
* I tested the minor version upgrade instructions on Ubuntu 14 and CentOS 7 by installing Citus 5.0 via OS package then building/installing 5.1 from source.
  * @jasonmp85 I am assuming apt-get upgrade will have the same effect once the 5.1 package is released.
* Major version upgrade instructions
  * They haven't changed much except to link to our installation guide rather than a download.
  * In particular it links to the installation requirements page because it felt more general than going explicitly to a single- or multi-machine install. However it's a slightly weird transition, see how you feel about it @sumedhpathak 
  * Also installing citus 5 via a package initializes a data dir so I removed that step.

Fixes #47 