### PR TITLE
Use citus-tutorial bundle built for 5.1

### DIFF
--- a/tutorials/tut-cluster.rst
+++ b/tutorials/tut-cluster.rst
@@ -11,9 +11,9 @@ To do the tutorials you'll need a single-machine Citus cluster with a master and
 .. raw:: html 
 
   <ul>
-  <li> OS X Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.0.0.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.0.0.tar.gz'); return false;">Download</a>
+  <li> OS X Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.1.0.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.1.0.tar.gz'); return false;">Download</a>
   </li>
-  <li> Linux Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.0.0.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.0.0.tar.gz'); return false;">Download</a>
+  <li> Linux Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.1.0.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.1.0.tar.gz'); return false;">Download</a>
   </li>
   </ul>
 


### PR DESCRIPTION
I built the new bundles and tested on Mac 10.11.5 and Ubuntu 16.04.

Can someone please independently verify that the tutorial works, preferably on a different Linux distribution? (Testing on something like CentOS 6 would probably be good since it's much older and has rather different internals.)

Fixes #49