### PR TITLE
Mention citus cloud in the AWS installation docs

### DIFF
--- a/installation/multi_machine_aws.rst
+++ b/installation/multi_machine_aws.rst
@@ -1,11 +1,33 @@
 .. _multi_machine_aws:
 
 Amazon Web Services
-===================
+###################
 
-This section describes the steps needed to set up a Citus cluster on AWS using the CloudFormation console.
+There are two approaches for running Citus on AWS. You can provision it manually using our CloudFormation template, or use Citus Cloud for automated provisioning, backup, and monitoring.
 
-To simplify the process of setting up a Citus cluster on `EC2 <http://aws.amazon.com/ec2/>`_, AWS users can use AWS CloudFormation. The CloudFormation template for Citus enables users to start a Citus cluster on AWS in just a few clicks, with also cstore_fdw extension for columnar storage is pre-installed. The template automates the installation and configuration process so that the users don’t need to do any extra configuration steps while installing Citus.
+.. _multi_machine_cloud:
+
+Managed Citus Cloud Deployment
+==============================
+
+Citus Cloud is a fully managed "Citus-as-a-Service" built on top of Amazon Web Services. It's an easy way to provision and monitor a high-availability cluster.
+
+.. raw:: html
+
+  <div class="wy-btn-group wy-text-center">
+    <a href="https://www.citusdata.com/cloud" class="btn btn-neutral"
+       onclick="trackOutboundLink('https://www.citusdata.com/cloud'); return false;">
+      Try Citus Cloud
+      <span class="fa fa-cloud"></span>
+    </a>
+  </div>
+
+.. _multi_machine_manual:
+
+Manual CloudFormation Deployment
+================================
+
+Alternately you can manage a Citus cluster manually on `EC2 <http://aws.amazon.com/ec2/>`_ instances using CloudFormation. The CloudFormation template for Citus enables users to start a Citus cluster on AWS in just a few clicks, with also cstore_fdw extension for columnar storage is pre-installed. The template automates the installation and configuration process so that the users don’t need to do any extra configuration steps while installing Citus.
 
 Please ensure that you have an active AWS account and an `Amazon EC2 key pair <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html>`_ before proceeding with the next steps.
 


### PR DESCRIPTION
Let people know it's an option and how it differs from CloudFormation.

I dug through our css and found existing styles `.wy-btn-group` and `.wy-text-center` to make my call to action button look the way I wanted. Not sure if it's a class I should rely on existing for the long term...