### PR TITLE
Amend range-distribution instructions based on new COPY changes

### DIFF
--- a/dist_tables/range_distribution.rst
+++ b/dist_tables/range_distribution.rst
@@ -40,7 +40,7 @@ This function informs Citus that the github_events table should be distributed b
 
 Range distribution signifies to the database that all the shards have
 non-overlapping ranges of the distribution key. Currently, the \\copy command
-for data loading expects that shard's have been created with non-overlapping
+for data loading expects that shards have been created with non-overlapping
 ranges, and cover the range of values expected in the file.
 
 For example, with the above use-case, you would first create shards using
@@ -49,8 +49,8 @@ and max values manually for that day, and \\COPY would then be able to load the
 data for the day. If \\COPY encounters a partition-column value which isn't
 covered by an existing shard, it will throw an error.
 
-The difference between range and append methods is that Citus’s distributed query planner has extra knowledge that the shards have distinct non-overlapping distribution key ranges. This allows the planner to push down more operations to the workers so that they can be executed in parallel. This reduces both the amount of data transferred across network and the amount of computation to be done for aggregation on the master.
+The difference between range and append methods is that Citus' distributed query planner has extra knowledge that the shards have distinct non-overlapping distribution key ranges. This allows the planner to push down more operations to the workers so that they can be executed in parallel. This reduces both the amount of data transferred across network and the amount of computation to be done for aggregation on the master.
 
 If you want more specific details on how to set up range partitioning, please get in touch with us via
-our mailing-list.
+our `mailing-list <https://groups.google.com/forum/#!forum/citus-users>`_.
 

--- a/dist_tables/range_distribution.rst
+++ b/dist_tables/range_distribution.rst
@@ -34,61 +34,23 @@ Next, you can use the master_create_distributed_table() function to mark the tab
 
 ::
 
-    SELECT master_create_distributed_table('github_events', 'repo_id', 'range');
+    SELECT master_create_distributed_table('github_events', 'created_at', 'range');
 
-This function informs Citus that the github_events table should be distributed by range on the repo_id column.
+This function informs Citus that the github_events table should be distributed by range on the created_at column.
 
-Range distribution signifies to the database that all the shards have non-overlapping ranges of the distribution key. Currently, the \\copy command for data loading does not impose that the shards have non-overlapping distribution key ranges. Hence, the user needs to make sure that the shards don't overlap.
+Range distribution signifies to the database that all the shards have
+non-overlapping ranges of the distribution key. Currently, the \\copy command
+for data loading expects that shard's have been created with non-overlapping
+ranges, and cover the range of values expected in the file.
 
-To set up range distributed shards, you first have to sort the data on the distribution column. This may not be required if the data already comes sorted on the distribution column (eg. facts, events, or time-series tables distributed on time). The next step is to split the input file into different files having non-overlapping ranges of the distribution key and run the \\copy command for each file separately. As \\copy always creates a new shard, the shards are guaranteed to have non-overlapping ranges.
-
-As an example, we'll describe how to copy data into the github_events table shown above. First, you download and extract two hours of github data.
-
-::
-
-    wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-0.csv.gz
-    wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-1.csv.gz
-    gzip -d github_events-2015-01-01-0.csv.gz
-    gzip -d github_events-2015-01-01-1.csv.gz
-
-Then, you merge both files into a single file by using the cat command.
-
-::
-
-    cat github_events-2015-01-01-0.csv github_events-2015-01-01-1.csv > github_events-2015-01-01-0-1.csv
-
-Next, you should sort the data on the repo_id column using the linux sort command.
-
-::
-
-    sort -n --field-separator=',' --key=4 github_events-2015-01-01-0-1.csv > github_events_sorted.csv
-
-Finally, you can split the input data such that no two files have any overlapping partition column ranges. This can be done by writing a custom script or manually ensuring that files don’t have overlapping ranges of the repo_id column.
-
-For this example, you can download and extract data that has been previously split on the basis of repo_id.
-
-::
-
-    wget http://examples.citusdata.com/github_archive/github_events_2015-01-01-0-1_range1.csv.gz 
-    wget http://examples.citusdata.com/github_archive/github_events_2015-01-01-0-1_range2.csv.gz 
-    wget http://examples.citusdata.com/github_archive/github_events_2015-01-01-0-1_range3.csv.gz 
-    wget http://examples.citusdata.com/github_archive/github_events_2015-01-01-0-1_range4.csv.gz
-    gzip -d github_events_2015-01-01-0-1_range1.csv.gz
-    gzip -d github_events_2015-01-01-0-1_range2.csv.gz
-    gzip -d github_events_2015-01-01-0-1_range3.csv.gz
-    gzip -d github_events_2015-01-01-0-1_range4.csv.gz
-
-Then, you can connect to the master using psql and load the files using the \\copy command.
-
-::
-
-    psql -h localhost -d postgres
-    SET citus.shard_replication_factor TO 1;
-    \copy github_events from 'github_events_2015-01-01-0-1_range1.csv' with csv
-    \copy github_events from 'github_events_2015-01-01-0-1_range2.csv' with csv
-    \copy github_events from 'github_events_2015-01-01-0-1_range3.csv' with csv
-    \copy github_events from 'github_events_2015-01-01-0-1_range4.csv' with csv
-
-After this point, you can run queries on the range distributed table. To generate per-repository metrics, your queries would generally have filters on the repo_id column. Then, Citus can easily prune away unrelated shards and ensure that the query hits only one shard. Also, groupings and orderings on repo_id can be easily pushed down the workers leading to more efficient queries. We also note here that all the commands which can be run on tables using the append distribution method can be run on tables using range distribution. This includes \\copy, the append and shard creation UDFs and the delete UDF. 
+For example, with the above use-case, you would first create shards using
+'master_create_empty_shard' for each day. Then, you would have to update the shard min
+and max values manually for that day, and \\COPY would then be able to load the
+data for the day. If \\COPY encounters a partition-column value which isn't
+covered by an existing shard, it will throw an error.
 
 The difference between range and append methods is that Citus’s distributed query planner has extra knowledge that the shards have distinct non-overlapping distribution key ranges. This allows the planner to push down more operations to the workers so that they can be executed in parallel. This reduces both the amount of data transferred across network and the amount of computation to be done for aggregation on the master.
+
+If you want more specific details on how to set up range partitioning, please get in touch with us via
+our mailing-list.
+


### PR DESCRIPTION
COPY behavior has changed so our instructions for range-distribution are no longer valid. For now we're keeping it simpler and minimizing specifics, since it involves manually updating min/max values. We may want to amend master_create_empty_shard or provide other UDF's to do this in an easier fashion.
