### PR TITLE
Add reassuring note after minor upgrade docs

### DIFF
--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -205,3 +205,6 @@ Restart PostgreSQL and run
 
   psql -c "\dx"
   # you should see a newer Citus 5.x version in the list
+
+That's all it takes! No further steps are necessary after updating
+the extension on all database instances in your cluster.


### PR DESCRIPTION
Some users were understandably a little incredulous that the short instructions for minor Citus upgrades are sufficient. Adding a reassuring note.