### PR TITLE
Allow trust for localhost in pg_hba.conf

### DIFF
--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -52,6 +52,10 @@ Before starting the database let's change its access permissions. By default the
   # correspond to 24, 20, and 16-bit blocks in Private IPv4 address spaces.
   host    all             all             10.0.0.0/8              trust
 
+  # Also allow the host unrestricted access to connect to itself
+  host    all             all             127.0.0.1/32            trust
+  host    all             all             ::1/128                 trust
+
 .. note::
   Your DNS settings may differ. Also these settings are too permissive for some environments. The PostgreSQL manual `explains how <http://www.postgresql.org/docs/9.5/static/auth-pg-hba-conf.html>`_ to make them more restrictive.
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -60,6 +60,10 @@ Before starting the database let's change its access permissions. By default the
   # correspond to 24, 20, and 16-bit blocks in Private IPv4 address spaces.
   host    all             all             10.0.0.0/8              trust
 
+  # Also allow the host unrestricted access to connect to itself
+  host    all             all             127.0.0.1/32            trust
+  host    all             all             ::1/128                 trust
+
 .. note::
   Your DNS settings may differ. Also these settings are too permissive for some environments. The PostgreSQL manual `explains how <http://www.postgresql.org/docs/9.5/static/auth-pg-hba-conf.html>`_ to make them more restrictive.
 


### PR DESCRIPTION
I reproduced #66 using a multi-machine Ubuntu setup. Workers need to be able to connect to themselves. Master doesn't necessarily need to connect to itself as well but it simplifies the documentation to use the same pg_hba.conf settings for all nodes including master.

Fixes #66