### PR TITLE
Add reassuring note after minor upgrade docs

### DIFF
--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -165,7 +165,7 @@ For users who don’t want to take a cluster down and upgrade all nodes at the s
 Minor Update to Latest 5.x
 ##########################
 
-Upgrading requires first obtaining the new Citus extension and then installing it in each of your database instances. The first step varies by operating system.
+Upgrading requires first obtaining the new Citus extension and then installing it in each of your database instances, doing the master instance last. The first step varies by operating system.
 
 .. _upgrading_citus_minor_package:
 

--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -206,3 +206,6 @@ Restart PostgreSQL and run
 
   psql -c "\dx"
   # you should see a newer Citus 5.x version in the list
+
+That's all it takes! No further steps are necessary after updating
+the extension on all database instances in your cluster.


### PR DESCRIPTION
Some users were understandably a little incredulous that the short instructions for minor Citus upgrades are sufficient. Adding a reassuring note.