### PR TITLE
Put hash distribution first, call it by its name

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -19,8 +19,8 @@ topics.
    :caption: Tutorials
 
    tutorials/tut-cluster.rst
-   tutorials/tut-real-time.rst
-   tutorials/tut-user-data.rst
+   tutorials/tut-hash-distribution.rst
+   tutorials/tut-append-distribution.rst
 
 .. toctree::
    :caption: Installation

--- a/index.rst
+++ b/index.rst
@@ -34,8 +34,8 @@ topics.
    :caption: Distributed Tables
 
    dist_tables/working_with_distributed_tables.rst
-   dist_tables/append_distribution.rst
    dist_tables/hash_distribution.rst
+   dist_tables/append_distribution.rst
    dist_tables/querying.rst
    dist_tables/postgresql_extensions.rst
 

--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -109,7 +109,7 @@ To verify that the installation has succeeded, we check that the master node has
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`real-time aggregation tutorial<tut_timeseries>` which has instructions on setting up a Citus cluster with sample data in minutes.
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<tut_sharding>` which has instructions on setting up a Citus cluster with sample data in minutes.
 
 Your new Citus database is accessible in psql through the postgres user:
 

--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -109,7 +109,7 @@ To verify that the installation has succeeded, we check that the master node has
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<tut_sharding>` which has instructions on setting up a Citus cluster with sample data in minutes.
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<tut_hash>` which has instructions on setting up a Citus cluster with sample data in minutes.
 
 Your new Citus database is accessible in psql through the postgres user:
 

--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -109,7 +109,7 @@ To verify that the installation has succeeded, we check that the master node has
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`real-time aggregation tutorial<tut_real_time>` which has instructions on setting up a Citus cluster with sample data in minutes.
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`real-time aggregation tutorial<tut_timeseries>` which has instructions on setting up a Citus cluster with sample data in minutes.
 
 Your new Citus database is accessible in psql through the postgres user:
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -116,7 +116,7 @@ To verify that the installation has succeeded, we check that the master node has
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<tut_sharding>` which has instructions on setting up a Citus cluster with sample data in minutes.
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<tut_hash>` which has instructions on setting up a Citus cluster with sample data in minutes.
 
 Your new Citus database is accessible in psql through the postgres user:
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -116,7 +116,7 @@ To verify that the installation has succeeded, we check that the master node has
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`real-time aggregation tutorial<tut_real_time>` which has instructions on setting up a Citus cluster with sample data in minutes.
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`real-time aggregation tutorial<tut_timeseries>` which has instructions on setting up a Citus cluster with sample data in minutes.
 
 Your new Citus database is accessible in psql through the postgres user:
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -116,7 +116,7 @@ To verify that the installation has succeeded, we check that the master node has
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`real-time aggregation tutorial<tut_timeseries>` which has instructions on setting up a Citus cluster with sample data in minutes.
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<tut_sharding>` which has instructions on setting up a Citus cluster with sample data in minutes.
 
 Your new Citus database is accessible in psql through the postgres user:
 

--- a/tutorials/tut-append-distribution.rst
+++ b/tutorials/tut-append-distribution.rst
@@ -1,12 +1,12 @@
 .. _tut_real_time:
 .. highlight:: bash
 
-Real Time Aggregation
-#####################
+Append-Distributed Data
+#######################
 
-In this tutorial we'll look at a stream of live wikipedia edits. Wikimedia is
-kind enough to publish all changes happening across all their sites in real time;
-this can be a lot of events!
+In this tutorial we'll continue looking at wikipedia edits. The previous
+tutorial ingested a stream of all live edits happening across wikimedia.  We'll
+continue looking at that stream but store it in a different way.
 
 This tutorial assumes you've set up a :ref:`single-machine demo cluster <tut_cluster>`.
 Our first task is to get the cluster ready to accept a stream of wikipedia edits.

--- a/tutorials/tut-append-distribution.rst
+++ b/tutorials/tut-append-distribution.rst
@@ -1,7 +1,7 @@
-.. _tut_real_time:
+.. _tut_timeseries:
 .. highlight:: bash
 
-Append-Distributed Data
+Working with Timeseries
 #######################
 
 In this tutorial we'll continue looking at wikipedia edits. The previous
@@ -143,9 +143,8 @@ Or how about combining the two? What are the top contributors, and how big are t
   WHERE new_length IS NOT NULL AND old_length IS NOT NULL
   GROUP BY 2 ORDER BY 1 DESC LIMIT 20;
 
-That's all for now. To learn more about Citus continue to the :doc:`next
-tutorial <./tut-user-data>`, or, if you're done with the cluster, run this to
-stop the worker and master:
+We hope you enjoyed working through our tutorials. Once you're ready to stop
+the cluster run these commands:
 
 ::
 

--- a/tutorials/tut-append-distribution.rst
+++ b/tutorials/tut-append-distribution.rst
@@ -1,8 +1,8 @@
-.. _tut_timeseries:
+.. _tut_append:
 .. highlight:: bash
 
-Working with Timeseries
-#######################
+Append-Distributed Data
+########################
 
 In this tutorial we'll continue looking at wikipedia edits. The previous
 tutorial ingested a stream of all live edits happening across wikimedia.  We'll

--- a/tutorials/tut-cluster.rst
+++ b/tutorials/tut-cluster.rst
@@ -82,5 +82,5 @@ load the user-facing side of Citus (such as the functions you'll soon call):
 **4. Ready for the tutorials!**
 
 Your cluster is running and eagerly awaiting data. Proceed to the 
-:ref:`Real Time Aggregation <tut_timeseries>` tutorial to begin learning
+:ref:`sharding tutorial<tut_sharding>` to begin learning
 how to use Citus.

--- a/tutorials/tut-cluster.rst
+++ b/tutorials/tut-cluster.rst
@@ -82,5 +82,5 @@ load the user-facing side of Citus (such as the functions you'll soon call):
 **4. Ready for the tutorials!**
 
 Your cluster is running and eagerly awaiting data. Proceed to the 
-:ref:`Real Time Aggregation <tut_real_time>` tutorial to begin learning
+:ref:`Real Time Aggregation <tut_timeseries>` tutorial to begin learning
 how to use Citus.

--- a/tutorials/tut-cluster.rst
+++ b/tutorials/tut-cluster.rst
@@ -82,5 +82,5 @@ load the user-facing side of Citus (such as the functions you'll soon call):
 **4. Ready for the tutorials!**
 
 Your cluster is running and eagerly awaiting data. Proceed to the 
-:ref:`sharding tutorial<tut_sharding>` to begin learning
+:ref:`sharding tutorial<tut_hash>` to begin learning
 how to use Citus.

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -1,4 +1,4 @@
-.. _tut_hash:
+.. _tut_sharding:
 .. highlight:: bash
 
 Sharding Data
@@ -147,9 +147,9 @@ This script showed a data layout which many Citus users choose. One
 table stored a stream of events while another table stored some
 aggregations of those events and made queries over them quick.
 
-That's all for now. To learn more about Citus continue to the :doc:`next
-tutorial <./tut-timeseries>`, or, if you're done with the cluster, run this to
-stop the worker and master:
+That's all for now. To learn more about Citus continue to the
+:ref:`next tutorial <tut_timeseries>`, or, if you're done with the
+cluster, run this to stop the worker and master:
 
 ::
 

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -1,8 +1,8 @@
 .. _tut_hash:
 .. highlight:: bash
 
-Hash-Distributed Data
-=====================
+Sharding Data
+=============
 
 In this tutorial we'll look at a stream of live wikipedia edits. Wikimedia is
 kind enough to publish all changes happening across all their sites in real time;
@@ -143,12 +143,13 @@ Usually, around a fifth of all non-bot edits are made from unregistered
 editors. The real percentage is a lot higher, since "bot" is a user-settable
 flag which many bots neglect to set.
 
-That's all for now. This script showed a data layout which many Citus users
-choose. One table stored a stream of events while another table stored some
+This script showed a data layout which many Citus users choose. One
+table stored a stream of events while another table stored some
 aggregations of those events and made queries over them quick.
 
-We hope you enjoyed working through our tutorials. Once you're ready to stop
-the cluster run these commands:
+That's all for now. To learn more about Citus continue to the :doc:`next
+tutorial <./tut-timeseries>`, or, if you're done with the cluster, run this to
+stop the worker and master:
 
 ::
 

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -1,8 +1,8 @@
-.. _tut_sharding:
+.. _tut_hash:
 .. highlight:: bash
 
-Sharding Data
-=============
+Hash-Distributed Data
+=====================
 
 In this tutorial we'll look at a stream of live wikipedia edits. Wikimedia is
 kind enough to publish all changes happening across all their sites in real time;
@@ -148,7 +148,7 @@ table stored a stream of events while another table stored some
 aggregations of those events and made queries over them quick.
 
 That's all for now. To learn more about Citus continue to the
-:ref:`next tutorial <tut_timeseries>`, or, if you're done with the
+:ref:`next tutorial <tut_append>`, or, if you're done with the
 cluster, run this to stop the worker and master:
 
 ::

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -1,12 +1,12 @@
 .. _tut_hash:
 .. highlight:: bash
 
-Updatable User Data
-===================
+Hash-Distributed Data
+=====================
 
-In this tutorial we'll continue looking at wikipedia edits. The previous
-tutorial ingested a stream of all live edits happening across wikimedia.  We'll
-continue looking at that stream but store it in a different way.
+In this tutorial we'll look at a stream of live wikipedia edits. Wikimedia is
+kind enough to publish all changes happening across all their sites in real time;
+this can be a lot of events!
 
 This tutorial assumes you've set up a :ref:`single-machine demo cluster <tut_cluster>`.
 Once your cluster is running, open a prompt to the master instance:


### PR DESCRIPTION
In addition to reordering the tutorials and swapping their intro paragraphs I changed their names. The new names are pretty literal, maybe too much so. However they are unambiguous.

Fixes #95
Fixes #28 