### PR TITLE
Revert "Document master_modify_multiple_shards UDF (#91)"

### DIFF
--- a/dist_tables/hash_distribution.rst
+++ b/dist_tables/hash_distribution.rst
@@ -97,8 +97,8 @@ For example:
 
     If COPY fails to open a connection for a shard placement then it behaves in the same way as INSERT, namely to mark the placement(s) as inactive unless there are no more active placements. If any other failure occurs after connecting, the transaction is rolled back and thus no metadata changes are made.
 
-Single-Shard Updates and Deletion
----------------------------------
+Updating and Deleting Data
+--------------------------
 
 You can also update or delete rows from your tables, using the standard PostgreSQL `UPDATE <http://www.postgresql.org/docs/9.5/static/sql-update.html>`_ and `DELETE <http://www.postgresql.org/docs/9.5/static/sql-delete.html>`_ commands.
 
@@ -107,19 +107,7 @@ You can also update or delete rows from your tables, using the standard PostgreS
     UPDATE github_events SET org = NULL WHERE repo_id = 24509048;
     DELETE FROM github_events WHERE repo_id = 24509048;
 
-Currently, Citus requires that standard UPDATE or DELETE statements involve exactly one shard. This means commands must include a WHERE qualification on the distribution column that restricts the query to a single shard. Such qualifications usually take the form of an equality clause on the table’s distribution column. To update or delete across shards see the section below.
-
-Cross-Shard Updates and Deletion
---------------------------------
-
-The most flexible way to modify or delete rows throughout a Citus cluster is the master_modify_multiple_shards command. It takes a regular SQL statement as argument and runs it on all workers:
-
-::
-
-  SELECT master_modify_multiple_shards(
-    'DELETE FROM github_events WHERE repo_id IN (24509048, 24509049)');
-
-This uses a two-phase commit to remove or update data safely everywhere. Unlike the standard UPDATE statement, Citus allows it to operate on more than one shard. To learn more about the function, its arguments and its usage, please visit the :ref:`user_defined_functions` section of our documentation.
+Currently, Citus requires that an UPDATE or DELETE involves exactly one shard. This means commands must include a WHERE qualification on the distribution column that restricts the query to a single shard. Such qualifications usually take the form of an equality clause on the table’s distribution column.
 
 Maximizing Write Performance
 ----------------------------

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -91,9 +91,6 @@ This example creates an empty shard for the github_events table. The shard id of
                     102089
     (1 row)
 
-Table and Shard DML
--------------------
-
 .. _master_append_table_to_shard:
 
 master_append_table_to_shard
@@ -168,34 +165,6 @@ The first example deletes all the shards for the github_events table since no de
     -----------------------------
                                3
     (1 row)
-
-master_modify_multiple_shards
-$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-
-The master_modify_multiple_shards() function is used to run a query against all shards which match the criteria specified by the query. As the function uses shard metadata to decide whether or not a shard needs to be updated, it requires the WHERE clause in the query to be on the distribution column. Depending on the value of citus.multi_shard_commit_protocol, the commit can be done in one- or two-phases.
-
-Limitations:
-
-* It cannot be called inside a transaction block
-* It must be called with simple operator expressions only
-
-Arguments
-**********
-
-**modify_query:** A simple DELETE or UPDATE query as a string.
-
-Return Value
-************
-
-N/A
-
-Example
-********
-
-::
-
-  SELECT master_modify_multiple_shards(
-    'DELETE FROM customer_delete_protocol WHERE c_custkey > 500 AND c_custkey < 500');
 
 Metadata / Configuration Information
 ------------------------------------------------------------------------


### PR DESCRIPTION
As @marcocitus noted, `master_modify_multiple_shards` has been checked in to the v5.1 branch, but isn't supported in Citus 5.1. It will be present in 5.2.

This PR removes mention of that UDF from the 5.1 docs. After merging this PR my next step will be to fast-forward master to the end of v5.1 (we've been playing catch-up with 5.1 features and that branch has gotten far ahead of master). I'll then cherry-pick 8a9fea52889faf107cdaad76f1e38895298ab4a8 on master.

I foresee a problem later where we want to document features that apply from a given version *onwards*. Copying the documentation for those features across all relevant doc versions might involve a lot of cherry picking. I've been trying to think of a branching structure that is well suited to making these kind of changes, and have some ideas but none are entirely satisfactory because they often involve heavy rebasing.

/cc @sumedhpathak 