### PR TITLE
Document common sql workarounds

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -66,6 +66,7 @@ topics.
    :caption: Reference
 
    reference/citus_sql_reference.rst
+   reference/sql_workarounds.rst
    reference/user_defined_functions.rst
    reference/metadata_tables.rst
    reference/configuration.rst

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -30,15 +30,13 @@ Another example. How many distinct sessions viewed the top twenty-five most visi
   select page_id, count(distinct session_id)
     from visits
    where page_id in (
-     select page_id from (
-       select page_id, count(1) as total
-         from visits
-        group by page_id
-        order by total desc
-        limit 25
-     ) as t
+     select page_id
+       from visits
+      group by page_id
+      order by count(*) desc
+      limit 25
    )
-   group by page_id
+   group by page_id;
 
 Citus does not allow subqueries in the WHERE clause so we must choose a workaround.
 

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -108,10 +108,14 @@ This does incur network cost. If this workaround is too slow please contact Citu
 SELECT DISTINCT (non-distribution column)
 -----------------------------------------
 
-Citus supports SELECT DISTINCT col but only when col is the shard distribution column. If it is not, use GROUP BY for a simple workaround:
+Citus does not yet support SELECT DISTINCT but you can use GROUP BY for a simple workaround:
 
 .. code-block:: sql
 
+  -- rather than this
+  -- select distinct col from table;
+
+  -- use this
   select col from table group by col;
 
 JOIN a local and a distributed table

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -1,0 +1,141 @@
+.. _workarounds:
+
+SQL Workarounds
+===============
+
+Citus supports most, but not all, SQL statements directly. Its SQL support continues to improve. Also many of the unsupported features have workarounds; below are a number of the most useful.
+
+Subqueries
+----------
+
+In analytics it is common to model information using a "star schema." This is a collection of dimensional tables (e.g. observations, statistics) referencing a table of facts (e.g. people, pages or events). Furthermore, a common form of query examines dimensions for a subset of the facts. Examples of these kind of queries:
+
+* "Get aggregated statistics about football players whose passes exceed three hundred yards."
+* "Which other pages do people visit who view a certain page?"
+* "Count the number of distinct sessions for the top twenty-five most visited blog posts."
+* "What is the number of people in companies among the top fifty product areas?"
+
+The general form of the query in SQL is
+
+.. code-block:: sql
+
+  select dim_a, dim_b, dim_c
+    from dimensions
+   where fact_id in (select id from facts where ...conditions...)
+     and ...conditions...;
+
+Citus does not allow subqueries in the WHERE clause so we must choose a workaround.
+
+Workaround 1. Generate explicit WHERE-IN expression
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Pros
+    * Able to distribute the query across shards
+* Cons
+    * Constructed query not suitable when facts subquery returns large number of results
+    * Somewhat hard to read, requires building custom SQL
+
+In this technique we use PL/pgSQL to construct and execute one statement based on the results of another.
+
+.. code-block:: sql
+
+  -- create temporary table with results
+  do language plpgsql $$
+    declare facts_array integer[];
+  begin 
+    execute 'select id from facts where ...conditions...'
+       into facts_array;
+    execute format(
+      'create temp table results_temp as '
+      'select dim_a, dim_b, dim_c'
+      '  from dimension'
+      ' where fact_id = any(array[%s])'
+      '   and ...conditions...',
+      array_to_string(facts_array, ','));
+  end;
+  $$;
+
+  -- read results, remove temp table
+  select * from results_temp;
+  drop table results_temp;
+
+
+Workaround 2. Join on Master
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Pros
+    * Works for subqueries returning any number of results
+* Cons
+    * Must transmit full rows from the queries back to the master
+    * Requires extra storage space in the master database
+
+In this workaround the client runs the outer- and sub-query independently, saves their results, and joins them.
+
+.. code-block:: sql
+
+  -- Capture the dimension query results
+  create temp table dim_temp as
+  select fact_id, dim_a, dim_b, dim_c
+    from dimensions
+   where ...conditions...;
+  
+  -- Capture the subquery results
+  create temp table fact_temp as
+  select id
+    from facts
+   where ...conditions...;
+  
+  -- Join them, get filtered dimension results
+  select dim_a, dim_b, dim_c
+    from dim_temp, fact_temp
+   where dim_temp.fact_id = fact_temp.id;
+
+  -- Remove temp tables
+  drop table dim_temp;
+  drop table fact_temp;
+
+SELECT ... INTO
+---------------
+
+Citus does not support inserting the results of a query into a distributed table with the standard SELECT INTO command. One workaround is to use two database connections to stream the query results to master and then distribute them to the shards.
+
+.. code-block:: bash
+
+  psql -c "COPY (query) TO STDOUT" | psql -c "COPY table FROM STDIN"
+
+This does incur network cost. If this workaround is too slow please contact Citus Data support. We can assist you in parallelizing the table insertion across all workers using a more complicated technique.
+
+SELECT DISTINCT (non-distribution column)
+-----------------------------------------
+
+Citus supports SELECT DISTINCT col but only when col is the shard distribution column. If it is not, use GROUP BY for a simple workaround:
+
+.. code-block:: sql
+
+  select col from table group by col;
+
+JOIN a local and a distributed table
+------------------------------------
+
+Attempting to execute a JOIN between a local and a distributed table causes an error:
+
+::
+
+  ERROR: cannot plan queries that include both regular and partitioned relations
+
+In Citus Community and Enterprise editions there is a workaround. You can replicate the local table to a single shard on every worker and push the join query down to the workers. Suppose we want to join tables *here* and *there*, where *there* is already distributed but *here* is on the master database.
+
+.. code-block:: sql
+
+  -- Allow "here" to be distributed
+  -- (presuming a primary key called "here_id")
+  SELECT master_create_distributed_table('here', 'here_id', 'hash');
+
+  -- Now make a full copy into a shard on every worker
+  SELECT master_create_worker_shards(
+    'here', 1,
+    (SELECT count(1) from master_get_active_worker_nodes())::integer
+  );
+
+Now Citus will accept a join query between *here* and *there*, and each worker will have all the information it needs to work efficiently. Note: Citus Cloud uses PostgreSQL replication, not Citus replication, so this technique does not work there.
+

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -60,8 +60,8 @@ In this technique we use PL/pgSQL to construct and execute one statement based o
   drop table results_temp;
 
 
-Workaround 2. Join on Master
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Workaround 2. Duplicate on Master
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Pros
     * Works for subqueries returning any number of results
@@ -85,10 +85,10 @@ In this workaround the client runs the outer- and sub-query independently, saves
     from facts
    where ...conditions...;
   
-  -- Join them, get filtered dimension results
+  -- Run the query on local tables where subqueries are OK
   select dim_a, dim_b, dim_c
-    from dim_temp, fact_temp
-   where dim_temp.fact_id = fact_temp.id;
+    from dim_temp
+   where fact_id in (select id from fact_temp);
 
   -- Remove temp tables
   drop table dim_temp;

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -82,7 +82,7 @@ In this technique we use PL/pgSQL to construct and execute one statement based o
   select * from results_temp;
   drop table results_temp;
 
-Workaround 1½. Build query in SQL client
+Workaround 2. Build query in SQL client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Pros
@@ -114,7 +114,7 @@ Interpolate the list of ids into a new query
    where page_id in (2,3,5,7,13)
   group by page_id
 
-Workaround 2. Use a JOIN
+Workaround 3. Use a JOIN
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Pros


### PR DESCRIPTION
Subqueries in where, select into, non-distribution column count distinct, join local and distributed.

When talking with @sumedhpathak we determined that hash partitioning on composite keys is actually more of a shard balancing technique than it is a SQL workaround.