### PR TITLE
Mark that shardalias is deprecated

### DIFF
--- a/reference/metadata_tables.rst
+++ b/reference/metadata_tables.rst
@@ -51,8 +51,8 @@ The pg_dist_shard table stores metadata about individual shards of a table. This
 | shardstorage   |            char      | | Type of storage used for this shard. Different storage types are        |
 |                |                      | | discussed in the table below.                                           |
 +----------------+----------------------+---------------------------------------------------------------------------+
-|  shardalias    |            text      | | Determines the name used on the worker PostgreSQL database to refer     |
-|                |                      | | to this shard. If NULL, the default name is "tablename_shardid".        |
+|  shardalias    |            text      | | Deprecated. This column doesn't do anything and will be removed in a    |
+|                |                      | | future release.                                                         |
 +----------------+----------------------+---------------------------------------------------------------------------+
 | shardminvalue  |            text      | | For append distributed tables, minimum value of the distribution column |
 |                |                      | | in this shard (inclusive).                                              |


### PR DESCRIPTION
If you don't want me to bug you with changes this small let me know :)

As of https://github.com/citusdata/citus/issues/739 we no longer respect `shardalias`.