### PR TITLE
Fix outbound links in presence of adblocker

### DIFF
--- a/_themes/citus/layout.html
+++ b/_themes/citus/layout.html
@@ -220,7 +220,7 @@ var createFunctionWithTimeout = function(callback, opt_timeout) {
 var trackOutboundLink = function(url) {
   ga('send', 'event', 'outbound', 'click', url, {
     'transport': 'beacon',
-    'hitCallback': createFunctionWithTimeout(function(){document.location = url;})
+    'hitCallback': createFunctionWithTimeout(function(){document.location = url;}, 500)
   });
 }
 </script>

--- a/_themes/citus/layout.html
+++ b/_themes/citus/layout.html
@@ -192,6 +192,25 @@
 
 </script>
 <script>
+
+/**
+* Workaround to ensure its argument *is* called within opt_timeout
+* of this function returning returning it for use in a callback.
+* This applies to Analytics callbacks which are thwarted by an
+* ad blocker.
+*/
+var createFunctionWithTimeout = function(callback, opt_timeout) {
+  var called = false;
+  function fn() {
+    if (!called) {
+      called = true;
+      callback();
+    }
+  }
+  setTimeout(fn, opt_timeout || 1000);
+  return fn;
+}
+
 /**
 * Function that tracks a click on an outbound link in Analytics.
 * This function takes a valid URL string as an argument, and uses that URL string
@@ -199,10 +218,10 @@
 * using 'navigator.sendBeacon' in browser that support it.
 */
 var trackOutboundLink = function(url) {
-   ga('send', 'event', 'outbound', 'click', url, {
-     'transport': 'beacon',
-     'hitCallback': function(){document.location = url;}
-   });
+  ga('send', 'event', 'outbound', 'click', url, {
+    'transport': 'beacon',
+    'hitCallback': createFunctionWithTimeout(function(){document.location = url;})
+  });
 }
 </script>
 

--- a/_themes/citus/layout.html
+++ b/_themes/citus/layout.html
@@ -195,7 +195,7 @@
 
 /**
 * Workaround to ensure its argument *is* called within opt_timeout
-* of this function returning returning it for use in a callback.
+* of this function returning it for use in a callback.
 * This applies to Analytics callbacks which are thwarted by an
 * ad blocker.
 */


### PR DESCRIPTION
If Google Analytics callback hasn't occurred one second after clicking a link, go ahead and run the callback ourselves because an adblocker has thwarted it. This techniques comes from the Google Analytics section about the [hitCallback](https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#handling_timeouts).

The particular timeout could perhaps be shortened because it feels like a long time for the link to activate. The danger with shortening it is interrupting analytics if GA is laggy.

Fixes #63