### PR TITLE
Migrate to new table creation API

### DIFF
--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -47,14 +47,14 @@ distribution column and create the worker shards.
 
 This function informs Citus that the github_events table should be distributed
 on the repo_id column (by hashing the column value). The function also creates
-shards on the worker nodes using the shard_count and shard_replication_factor
-configuration values.
+shards on the worker nodes using the citus.shard_count and
+citus.shard_replication_factor configuration values.
 
 This example would create a total of citus.shard_count number of shards where each
 shard owns a portion of a hash token space and gets replicated based on the
 default citus.shard_replication_factor configuration value. The shard replicas
-created on the worker has the same table schema, index, and constraint
-definitions as the table on the master. Once the replica is created, this
+created on the worker have the same table schema, index, and constraint
+definitions as the table on the master. Once the replicas are created, this
 function saves all distributed metadata on the master.
 
 Each created shard is assigned a unique shard id and all its replicas have the same shard id. Each shard is represented on the worker node as a regular PostgreSQL table with name 'tablename_shardid' where tablename is the name of the distributed table and shardid is the unique id assigned to that shard. You can connect to the worker postgres instances to view or run commands on individual shards.

--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -43,16 +43,19 @@ distribution column and create the worker shards.
 
 ::
 
-    SET citus.shard_replication_factor = 1;
-    SET citus.shard_count = 16;
-    SELECT create_distributed_table('github_events', 'repo_id', 'hash');
+    SELECT create_distributed_table('github_events', 'repo_id');
 
 This function informs Citus that the github_events table should be distributed
 on the repo_id column (by hashing the column value). The function also creates
 shards on the worker nodes using the shard_count and shard_replication_factor
 configuration values.
 
-This example would create a total of sixteen shards where each shard owns a portion of a hash token space and gets replicated on one worker. The shard replica created on the worker has the same table schema, index, and constraint definitions as the table on the master. Once the replica is created, this function saves all distributed metadata on the master.
+This example would create a total of citus.shard_count number of shards where each
+shard owns a portion of a hash token space and gets replicated based on the
+default citus.shard_replication_factor configuration value. The shard replicas
+created on the worker has the same table schema, index, and constraint
+definitions as the table on the master. Once the replica is created, this
+function saves all distributed metadata on the master.
 
 Each created shard is assigned a unique shard id and all its replicas have the same shard id. Each shard is represented on the worker node as a regular PostgreSQL table with name 'tablename_shardid' where tablename is the name of the distributed table and shardid is the unique id assigned to that shard. You can connect to the worker postgres instances to view or run commands on individual shards.
 

--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -38,25 +38,25 @@ To create a distributed table, you need to first define the table schema. To do 
     	created_at timestamp
     );
 
-Next, you can use the master_create_distributed_table() function to specify the table distribution column.
+Next, you can use the create_distributed_table() function to specify the table
+distribution column and create the worker shards.
 
 ::
 
-    SELECT master_create_distributed_table('github_events', 'repo_id', 'hash');
+    SET citus.shard_replication_factor = 1;
+    SET citus.shard_count = 16;
+    SELECT create_distributed_table('github_events', 'repo_id', 'hash');
 
-This function informs Citus that the github_events table should be distributed on the repo_id column (by hashing the column value).
+This function informs Citus that the github_events table should be distributed
+on the repo_id column (by hashing the column value). The function also creates
+shards on the worker nodes using the shard_count and shard_replication_factor
+configuration values.
 
-Then, you can create shards for the distributed table on the worker nodes using the master_create_worker_shards() UDF.
-
-::
-
-    SELECT master_create_worker_shards('github_events', 16, 1);
-
-This UDF takes two arguments in addition to the table name; shard count and the replication factor. This example would create a total of sixteen shards where each shard owns a portion of a hash token space and gets replicated on one worker. The shard replica created on the worker has the same table schema, index, and constraint definitions as the table on the master. Once the replica is created, this function saves all distributed metadata on the master.
+This example would create a total of sixteen shards where each shard owns a portion of a hash token space and gets replicated on one worker. The shard replica created on the worker has the same table schema, index, and constraint definitions as the table on the master. Once the replica is created, this function saves all distributed metadata on the master.
 
 Each created shard is assigned a unique shard id and all its replicas have the same shard id. Each shard is represented on the worker node as a regular PostgreSQL table with name 'tablename_shardid' where tablename is the name of the distributed table and shardid is the unique id assigned to that shard. You can connect to the worker postgres instances to view or run commands on individual shards.
 
-After creating the worker shard, you are ready to insert data into the distributed table and run queries on it. You can also learn more about the UDFs used in this section in the :ref:`user_defined_functions` of our documentation.
+You are now ready to insert data into the distributed table and run queries on it. You can also learn more about the UDF used in this section in the :ref:`user_defined_functions` of our documentation.
 
 Dropping Tables
 ---------------

--- a/performance/scaling_data_ingestion.rst
+++ b/performance/scaling_data_ingestion.rst
@@ -16,8 +16,7 @@ When processing an INSERT, Citus first finds the right shard placements based on
 
     -- Set up a distributed table containing counters
     CREATE TABLE counters (c_key text, c_date date, c_value int, primary key (c_key, c_date));
-    SELECT master_create_distributed_table('counters', 'c_key', 'hash');
-    SELECT master_create_worker_shards('counters', 128, 2);
+    SELECT create_distributed_table('counters', 'c_key', 'hash');
 
     -- Enable timing to see reponse times
     \timing on

--- a/performance/scaling_data_ingestion.rst
+++ b/performance/scaling_data_ingestion.rst
@@ -16,6 +16,7 @@ When processing an INSERT, Citus first finds the right shard placements based on
 
     -- Set up a distributed table containing counters
     CREATE TABLE counters (c_key text, c_date date, c_value int, primary key (c_key, c_date));
+    SET citus.shard_count = 128;
     SELECT create_distributed_table('counters', 'c_key', 'hash');
 
     -- Enable timing to see reponse times

--- a/performance/scaling_data_ingestion.rst
+++ b/performance/scaling_data_ingestion.rst
@@ -16,8 +16,7 @@ When processing an INSERT, Citus first finds the right shard placements based on
 
     -- Set up a distributed table containing counters
     CREATE TABLE counters (c_key text, c_date date, c_value int, primary key (c_key, c_date));
-    SET citus.shard_count = 128;
-    SELECT create_distributed_table('counters', 'c_key', 'hash');
+    SELECT create_distributed_table('counters', 'c_key');
 
     -- Enable timing to see reponse times
     \timing on

--- a/reference/append.rst
+++ b/reference/append.rst
@@ -81,11 +81,11 @@ To create an append distributed table, you need to first define the table schema
     	created_at timestamp
     );
 
-Next, you can use the master_create_distributed_table() function to mark the table as an append distributed table and specify its distribution column.
+Next, you can use the create_distributed_table() function to mark the table as an append distributed table and specify its distribution column.
 
 ::
 
-    SELECT master_create_distributed_table('github_events', 'created_at', 'append');
+    SELECT create_distributed_table('github_events', 'created_at', 'append');
 
 This function informs Citus that the github_events table should be distributed by append on the created_at column. Note that this method doesn't enforce a particular distribution; it merely tells the database to keep minimum and maximum values for the created_at column in each shard which are later used by the database for optimizing queries.
 
@@ -216,7 +216,7 @@ To ingest data into an append distributed table, you can use the `COPY <http://w
 
     -- Set up the events table
     CREATE TABLE events (time timestamp, data jsonb);
-    SELECT master_create_distributed_table('events', 'time', 'append');
+    SELECT create_distributed_table('events', 'time', 'append');
 
     -- Add data into a new staging table
     \COPY events FROM 'path-to-csv-file' WITH CSV
@@ -339,7 +339,7 @@ For example, assume we have the following table schema and want to load the comp
         org jsonb,
         created_at timestamp
     );
-    SELECT master_create_distributed_table('github_events', 'created_at', 'append');
+    SELECT create_distributed_table('github_events', 'created_at', 'append');
 
 
 To load the data, we can download the data, decompress it, filter out unsupported rows, and extract the fields in which we are interested into a staging table using 3 commands:

--- a/reference/configuration.rst
+++ b/reference/configuration.rst
@@ -48,6 +48,13 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 Sets the replication factor for shards i.e. the number of nodes on which shards will be placed and defaults to 2. This parameter can be set at run-time and is effective on the master.
 The ideal value for this parameter depends on the size of the cluster and rate of node failure. For example, you may want to increase this replication factor if you run large clusters and observe node failures on a more frequent basis.
 
+citus.shard_count (integer)
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+Sets the shard count for hash-partitioned tables and defaults to 32. This value is used by
+the create_distributed_table() UDF when creating hash-partitioned tables. This
+parameter can be set at run-time and is effective on the master. 
+
 citus.shard_max_size (integer)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 

--- a/reference/configuration.rst
+++ b/reference/configuration.rst
@@ -52,8 +52,8 @@ citus.shard_count (integer)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
 Sets the shard count for hash-partitioned tables and defaults to 32. This value is used by
-the create_distributed_table() UDF when creating hash-partitioned tables. This
-parameter can be set at run-time and is effective on the master. 
+the :ref:`create_distributed_table <create_distributed_table>` UDF when creating
+hash-partitioned tables. This parameter can be set at run-time and is effective on the master. 
 
 citus.shard_max_size (integer)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -135,7 +135,11 @@ Attempting to execute a JOIN between a local and a distributed table causes an e
 In Citus Community and Enterprise editions there is a workaround. You can
 replicate the local table to a single shard on every worker and push the join
 query down to the workers. We do this by defining the table as a 'reference'
-table using a different table creation API. Suppose we want to join tables *here* and *there*, where *there* is already distributed but *here* is on the master database.
+table using a different table creation API and setting
+citus.shard_replication_factor to the current number of worker nodes. Suppose we
+want to join tables *here* and *there*, where *there* is already distributed but
+*here* is on the master database.
+
 
 .. code-block:: sql
 

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -13,11 +13,11 @@ create_distributed_table
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
 The create_distributed_table() function is used to define a distributed table
-and create its shards if its a hash-partitioned table. This function takes in a
+and create its shards if its a hash-distributed table. This function takes in a
 table name, the distribution column and an optional distribution method and inserts
 appropriate metadata to mark the table as distributed. The function defaults to
 'hash' distribution if no distribution method is specified. If the table is
-hash-partitioned, the function also creates worker shards based on the shard
+hash-distributed, the function also creates worker shards based on the shard
 count and shard replication factor configuration values. This function replaces
 usage of master_create_distributed_table() followed by
 master_create_worker_shards(). 
@@ -52,8 +52,8 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 The create_reference_table() function is used to define a small reference or
 dimension table. This function takes in a table name, and creates a distributed
 table with just one shard, and replication factor equal to the value specified
-in the GUC. The partition column is unimportant since the UDF only creates one
-shard for the table.
+in the citus.shard_replication_factor configuration variable. The distribution
+column is unimportant since the UDF only creates one shard for the table.
 
 Arguments
 ************************
@@ -78,6 +78,9 @@ reference table
 master_create_distributed_table
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 .. _master_create_distributed_table:
+
+.. note::
+   This function is deprecated, and replaced by :ref:`create_distributed_table <create_distributed_table>`.
 
 The master_create_distributed_table() function is used to define a distributed
 table. This function takes in a table name, the distribution column and
@@ -107,12 +110,13 @@ This example informs the database that the github_events table should be distrib
 
 	SELECT master_create_distributed_table('github_events', 'repo_id', 'hash');
 
-.. note::
-   This function is deprecated, and replaced by :ref:`create_distributed_table <create_distributed_table>`.
 
 master_create_worker_shards
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 .. _master_create_worker_shards:
+
+.. note::
+   This function is deprecated, and replaced by :ref:`create_distributed_table <create_distributed_table>`.
 
 The master_create_worker_shards() function creates a specified number of worker shards with the desired replication factor for a *hash* distributed table. While doing so, the function also assigns a portion of the hash token space (which spans between -2 Billion and 2 Billion) to each shard. Once all shards are created, this function saves all distributed metadata on the master.
 
@@ -138,8 +142,6 @@ This example usage would create a total of 16 shards for the github_events table
 
 	SELECT master_create_worker_shards('github_events', 16, 2);
 
-.. note::
-   This function is deprecated, and replaced by :ref:`create_distributed_table <create_distributed_table>`.
 
 master_create_empty_shard
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -8,6 +8,70 @@ This section contains reference information for the User Defined Functions provi
 Table and Shard DDL
 -------------------
 
+create_distributed_table
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+.. _create_distributed_table:
+
+The create_distributed_table() function is used to define a distributed table
+and create its shards if its a hash-partitioned table. This function takes in a
+table name, the distribution column and distribution method and inserts
+appropriate metadata to mark the table as distributed. If the table is
+hash-partitioned, the function also creates worker shards based on the shard
+count configuration value. This function replaces usage of
+master_create_distributed_table() followed by master_create_worker_shards(). 
+
+Arguments
+************************
+
+**table_name:** Name of the table which needs to be distributed.
+
+**distribution_column:** The column on which the table is to be distributed.
+
+**distribution_method:** The method according to which the table is to be distributed. Permissible values are append or hash.
+
+Return Value
+********************************
+
+N/A
+
+Example
+*************************
+This example informs the database that the github_events table should be distributed by hash on the repo_id column.
+
+::
+
+	SELECT create_distributed_table('github_events', 'repo_id', 'hash');
+
+create_reference_table
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+.. _create_reference_table:
+
+The create_reference_table() function is used to define a small reference or
+dimension table. This function takes in a table name, and creates a distributed
+table with just one shard, and replication factor equal to the value specified
+in the GUC. The partition column is unimportant since the UDF only creates one
+shard for the table.
+
+Arguments
+************************
+
+**table_name:** Name of the small dimension or reference table which needs to be distributed.
+
+
+Return Value
+********************************
+
+N/A
+
+Example
+*************************
+This example informs the database that the nation table should be defined as a
+reference table
+
+::
+
+	SELECT create_reference_table('nation');
+
 master_create_distributed_table
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 .. _master_create_distributed_table:

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -7,18 +7,20 @@ This section contains reference information for the User Defined Functions provi
 
 Table and Shard DDL
 -------------------
+.. _create_distributed_table:
 
 create_distributed_table
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-.. _create_distributed_table:
 
 The create_distributed_table() function is used to define a distributed table
 and create its shards if its a hash-partitioned table. This function takes in a
-table name, the distribution column and distribution method and inserts
-appropriate metadata to mark the table as distributed. If the table is
+table name, the distribution column and an optional distribution method and inserts
+appropriate metadata to mark the table as distributed. The function defaults to
+'hash' distribution if no distribution method is specified. If the table is
 hash-partitioned, the function also creates worker shards based on the shard
-count configuration value. This function replaces usage of
-master_create_distributed_table() followed by master_create_worker_shards(). 
+count and shard replication factor configuration values. This function replaces
+usage of master_create_distributed_table() followed by
+master_create_worker_shards(). 
 
 Arguments
 ************************
@@ -27,7 +29,8 @@ Arguments
 
 **distribution_column:** The column on which the table is to be distributed.
 
-**distribution_method:** The method according to which the table is to be distributed. Permissible values are append or hash.
+**distribution_method:** (Optional) The method according to which the table is
+to be distributed. Permissible values are append or hash, and defaults to 'hash'.
 
 Return Value
 ********************************
@@ -40,7 +43,7 @@ This example informs the database that the github_events table should be distrib
 
 ::
 
-	SELECT create_distributed_table('github_events', 'repo_id', 'hash');
+	SELECT create_distributed_table('github_events', 'repo_id');
 
 create_reference_table
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
@@ -76,7 +79,11 @@ master_create_distributed_table
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 .. _master_create_distributed_table:
 
-The master_create_distributed_table() function is used to define a distributed table. This function takes in a table name, the distribution column and distribution method and inserts appropriate metadata to mark the table as distributed.
+The master_create_distributed_table() function is used to define a distributed
+table. This function takes in a table name, the distribution column and
+distribution method and inserts appropriate metadata to mark the table as
+distributed.
+
 
 Arguments
 ************************
@@ -100,6 +107,8 @@ This example informs the database that the github_events table should be distrib
 
 	SELECT master_create_distributed_table('github_events', 'repo_id', 'hash');
 
+.. note::
+   This function is deprecated, and replaced by :ref:`create_distributed_table <create_distributed_table>`.
 
 master_create_worker_shards
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
@@ -128,6 +137,9 @@ This example usage would create a total of 16 shards for the github_events table
 ::
 
 	SELECT master_create_worker_shards('github_events', 16, 2);
+
+.. note::
+   This function is deprecated, and replaced by :ref:`create_distributed_table <create_distributed_table>`.
 
 master_create_empty_shard
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$

--- a/tech_soln/real_time_dashboards.rst
+++ b/tech_soln/real_time_dashboards.rst
@@ -136,7 +136,7 @@ for each of the last 30 days.
 
 This looks a lot like the previous code block. Most importantly: It also shards on
 ``site_id`` and uses the same default configuration for shard count and
-replication factor.. Because all three of those match, there's a 1-to-1
+replication factor. Because all three of those match, there's a 1-to-1
 correspondence between ``http_request`` shards and ``http_request_1min`` shards,
 and Citus will place matching shards on the same worker. This is called
 colocation; it makes queries such as joins faster and our rollups possible.

--- a/tech_soln/real_time_dashboards.rst
+++ b/tech_soln/real_time_dashboards.rst
@@ -54,18 +54,19 @@ to demonstrate the overall architecture; a real system might use additional colu
     status_code INT,
     response_time_msec INT
   );
-  SELECT master_create_distributed_table('http_request', 'site_id', 'hash');
-  SELECT master_create_worker_shards('http_request', 16, 2);
 
-When we call :ref:`master_create_distributed_table <master_create_distributed_table>`
+  SET citus.shard_count = 16;
+  SELECT create_distributed_table('http_request', 'site_id', 'hash');
+
+When we call :ref:`create_distributed_table <create_distributed_table>`
 we ask Citus to hash-distribute ``http_request`` using the ``site_id`` column. That means
 all the data for a particular site will live in the same shard.
 
-When we call :ref:`master_create_worker_shards <master_create_worker_shards>` we tell
-Citus to create 16 shards and 2 replicas of each shard (for a total of 32 shard replicas).
-We recommend :ref:`using 2-4x as many shards <faq_choose_shard_count>` as CPU cores in
-your cluster. Using this many shards lets you rebalance data across your cluster after
-adding new worker nodes.
+By setting shard_count to 16, we tell the UDF to create 16 shards and 2 replicas
+of each shard (for a total of 32 shard replicas). We recommend :ref:`using 2-4x
+as many shards <faq_choose_shard_count>` as CPU cores in your cluster. Using
+this many shards lets you rebalance data across your cluster after adding new
+worker nodes.
 
 Using a replication factor of 2 means every shard is held on multiple workers. When a
 worker fails the master will prevent downtime by serving queries for that worker's shards
@@ -128,8 +129,9 @@ for each of the last 30 days.
         CHECK (request_count = error_count + success_count),
         CHECK (ingest_time = date_trunc('minute', ingest_time))
   );
-  SELECT master_create_distributed_table('http_request_1min', 'site_id', 'hash');
-  SELECT master_create_worker_shards('http_request_1min', 16, 2);
+
+  SET citus.shard_count = 16;
+  SELECT create_distributed_table('http_request_1min', 'site_id', 'hash');
   
   -- indexes aren't automatically created by Citus
   -- this will create the index on all shards

--- a/tech_soln/real_time_dashboards.rst
+++ b/tech_soln/real_time_dashboards.rst
@@ -55,18 +55,16 @@ to demonstrate the overall architecture; a real system might use additional colu
     response_time_msec INT
   );
 
-  SET citus.shard_count = 16;
-  SELECT create_distributed_table('http_request', 'site_id', 'hash');
+  SELECT create_distributed_table('http_request', 'site_id');
 
 When we call :ref:`create_distributed_table <create_distributed_table>`
 we ask Citus to hash-distribute ``http_request`` using the ``site_id`` column. That means
 all the data for a particular site will live in the same shard.
 
-By setting shard_count to 16, we tell the UDF to create 16 shards and 2 replicas
-of each shard (for a total of 32 shard replicas). We recommend :ref:`using 2-4x
-as many shards <faq_choose_shard_count>` as CPU cores in your cluster. Using
-this many shards lets you rebalance data across your cluster after adding new
-worker nodes.
+The UDF uses the default configuration values for shard count and replication
+factor. We recommend :ref:`using 2-4x as many shards <faq_choose_shard_count>`
+as CPU cores in your cluster. Using this many shards lets you rebalance data
+across your cluster after adding new worker nodes.
 
 Using a replication factor of 2 means every shard is held on multiple workers. When a
 worker fails the master will prevent downtime by serving queries for that worker's shards
@@ -130,18 +128,18 @@ for each of the last 30 days.
         CHECK (ingest_time = date_trunc('minute', ingest_time))
   );
 
-  SET citus.shard_count = 16;
-  SELECT create_distributed_table('http_request_1min', 'site_id', 'hash');
+  SELECT create_distributed_table('http_request_1min', 'site_id');
   
   -- indexes aren't automatically created by Citus
   -- this will create the index on all shards
   CREATE INDEX http_request_1min_idx ON http_request_1min (site_id, ingest_time);
 
 This looks a lot like the previous code block. Most importantly: It also shards on
-``site_id`` and it also uses 16 shards with 2 replicas of each. Because all three of
-those match, there's a 1-to-1 correspondence between ``http_request`` shards and
-``http_request_1min`` shards, and Citus will place matching shards on the same worker.
-This is called colocation; it makes queries such as joins faster and our rollups possible.
+``site_id`` and uses the same default configuration for shard count and
+replication factor.. Because all three of those match, there's a 1-to-1
+correspondence between ``http_request`` shards and ``http_request_1min`` shards,
+and Citus will place matching shards on the same worker. This is called
+colocation; it makes queries such as joins faster and our rollups possible.
 
 .. image:: /images/colocation.png
   :alt: colocation in citus

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -135,24 +135,19 @@ should be distributed tables, stored across the cluster.
 
 .. code-block:: sql
 
-  SET citus.shard_count = 16;
   SET citus.shard_replication_factor = 1;
 
-  SELECT create_distributed_table(
-    'wikipedia_changes', 'editor', 'hash'
-  );
-  SELECT create_distributed_table(
-    'wikipedia_editors', 'editor', 'hash'
-  );
+  SELECT create_distributed_table('wikipedia_changes', 'editor');
+  SELECT create_distributed_table('wikipedia_editors', 'editor');
 
 These say to store each table as a collection of shards, each
 responsible for holding a different subset of the data. The shard
 a particular row belongs in will be computed by hashing the ``editor``
 column. The page on :ref:`distributed_tables` goes into more detail.
 
-This tells Citus to create 16 shards for each table, and save 1 replica of
-each. You can ask Citus to store multiple copies of each shard, which allows it
-to recover from worker failures without losing data or dropping queries.
+This tells Citus to create citus.shard_count shards for each table, and save 1
+replica of each. You can ask Citus to store multiple copies of each shard, which
+allows it to recover from worker failures without losing data or dropping queries.
 However, in this example cluster we only have 1 worker, so Citus would error
 out if we asked it to store any more than 1 replica.
 

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -135,10 +135,13 @@ should be distributed tables, stored across the cluster.
 
 .. code-block:: sql
 
-  SELECT master_create_distributed_table(
+  SET citus.shard_count = 16;
+  SET citus.shard_replication_factor = 1;
+
+  SELECT create_distributed_table(
     'wikipedia_changes', 'editor', 'hash'
   );
-  SELECT master_create_distributed_table(
+  SELECT create_distributed_table(
     'wikipedia_editors', 'editor', 'hash'
   );
 
@@ -146,13 +149,6 @@ These say to store each table as a collection of shards, each
 responsible for holding a different subset of the data. The shard
 a particular row belongs in will be computed by hashing the ``editor``
 column. The page on :ref:`distributed_tables` goes into more detail.
-
-Finally, create the shards:
-
-.. code-block:: sql
-
-  SELECT master_create_worker_shards('wikipedia_editors', 16, 1);
-  SELECT master_create_worker_shards('wikipedia_changes', 16, 1);
 
 This tells Citus to create 16 shards for each table, and save 1 replica of
 each. You can ask Citus to store multiple copies of each shard, which allows it

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -145,8 +145,8 @@ responsible for holding a different subset of the data. The shard
 a particular row belongs in will be computed by hashing the ``editor``
 column. The page on :ref:`distributed_tables` goes into more detail.
 
-This tells Citus to create citus.shard_count shards for each table, and save 1
-replica of each. You can ask Citus to store multiple copies of each shard, which
+In addition, these UDF's create citus.shard_count shards for each table, and save one
+replica of each shard. You can ask Citus to store multiple copies of each shard, which
 allows it to recover from worker failures without losing data or dropping queries.
 However, in this example cluster we only have 1 worker, so Citus would error
 out if we asked it to store any more than 1 replica.


### PR DESCRIPTION
Move all relevant usage of master_create_distributed_table.

The tutorials (and indeed the rest of the documentation) will require it to be rebundled with 6.0. 

I left the section in [scaling data ingest](http://docs.citusdata.com/en/v5.2/performance/scaling_data_ingestion.html#masterless-citus-50k-s-500k-s) as-is. The usage first creates distributed tables on all nodes, and then creates shards from only one. We have a separate issue to replace this section with MX:  #189 . This usage will go away with that issue.

I'm not super happy with the SQL Workarounds change, as its not as easily copy-pasteable as the previous version. I couldn't figure out an easy way to assign a variable  the value returned from a SQL statement. 

Fixes #180 .