### PR TITLE
Replace use of pg_worker_list with new node API

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -29,7 +29,7 @@ Example:
 
 ::
 
-   SELECT master_add_node('node-name', 5432);
+   SELECT * from master_add_node('node-name', 5432);
 
 In addition to the above, if you want to move existing shards to the newly added worker, Citus Enterprise provides an additional rebalance_table_shards function to make this easier. This function will move the shards of the given table to make them evenly distributed among the workers.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -23,8 +23,8 @@ Adding a worker
 Citus stores all the data for distributed tables on the worker nodes. Hence, if you want to scale out your cluster by adding more computing power, you can do so by adding a worker.
 
 To add a new node to the cluster, you first need to add the DNS name of that
-node and port in the pg_dist_node catalog table. You can do so using the
-:ref:`master_add_node` UDF.
+node and port (on which PostgreSQL is running) in the pg_dist_node catalog
+table. You can do so using the :ref:`master_add_node` UDF.
 Example:
 
 ::
@@ -66,7 +66,7 @@ Citus can easily tolerate worker node failures because of its logical sharding-b
 On seeing such warnings, the first step would be to log into the failed node and
 inspect the cause of the failure.
 
-Citus will automatically re-route the work to the healthy workers. Also, if Citus is not able to connect to a worker, it will assign that task to another node having a copy of that shard. If the failure occurs mid-query, Citus does not re-run the whole query but assigns only the failed query fragments leading to faster responses in face of failures.
+In the meanwhile, Citus will automatically re-route the work to the healthy workers. Also, if Citus is not able to connect to a worker, it will assign that task to another node having a copy of that shard. If the failure occurs mid-query, Citus does not re-run the whole query but assigns only the failed query fragments leading to faster responses in face of failures.
 
 Once the node is brought back up, Citus will automatically continue connecting to it and
 using the data. 
@@ -77,8 +77,9 @@ make this simpler, Citus enterprise provides a replicate_table_shards UDF which
 can be called after. This function copies the shards of a table across the
 healthy nodes so they all reach the configured replication factor.
 
-First, you should mark all shard placements on that node as invalid (if they are
-not already so) using the following query:
+To remove a permanently failed node from the list of workers, you should first
+mark all shard placements on that node as invalid (if they are not already so)
+using the following query:
 
 ::
 

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -10,8 +10,8 @@ Currently Citus imposes primary key constraint only if the distribution column i
 How do I add nodes to an existing Citus cluster?
 ------------------------------------------------
 
-You can add nodes to a Citus cluster by adding the DNS host name and port of the
-new node to the pg_dist_node catalog table. After adding a node to an existing cluster, it will not contain any data (shards). Citus will start assigning any newly created shards to this node. To rebalance existing shards from the older nodes to the new node, the Citus Enterprise edition provides a shard rebalancer utility. You can find more information about shard rebalancing in the :ref:`cluster_management` section.
+You can add nodes to a Citus cluster by calling the master_add_node UDF with the
+hostname and port number of the new node. After adding a node to an existing cluster, it will not contain any data (shards). Citus will start assigning any newly created shards to this node. To rebalance existing shards from the older nodes to the new node, the Citus Enterprise edition provides a shard rebalancer utility. You can find more information about shard rebalancing in the :ref:`cluster_management` section.
 
 How do I change the shard count for a hash partitioned table?
 -------------------------------------------------------------

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -10,7 +10,8 @@ Currently Citus imposes primary key constraint only if the distribution column i
 How do I add nodes to an existing Citus cluster?
 ------------------------------------------------
 
-You can add nodes to a Citus cluster by adding the DNS host name and port of the new node to the pg_worker_list.conf configuration file in the data directory. After adding a node to an existing cluster, it will not contain any data (shards). Citus will start assigning any newly created shards to this node. To rebalance existing shards from the older nodes to the new node, the Citus Enterprise edition provides a shard rebalancer utility. You can find more information about shard rebalancing in the :ref:`cluster_management` section
+You can add nodes to a Citus cluster by adding the DNS host name and port of the
+new node to the pg_dist_node catalog table. After adding a node to an existing cluster, it will not contain any data (shards). Citus will start assigning any newly created shards to this node. To rebalance existing shards from the older nodes to the new node, the Citus Enterprise edition provides a shard rebalancer utility. You can find more information about shard rebalancing in the :ref:`cluster_management` section.
 
 How do I change the shard count for a hash partitioned table?
 -------------------------------------------------------------

--- a/installation/multi_machine_aws.rst
+++ b/installation/multi_machine_aws.rst
@@ -106,7 +106,7 @@ Once the cluster creation completes, you can immediately connect to the master n
 
 **7. Ready to use the cluster**
 
-At this step, you have completed the installation process and are ready to use the Citus cluster. You can now login to the master node and start executing commands. The command below, when run in the psql shell, should output the worker nodes mentioned in the pg_worker_list.conf.
+At this step, you have completed the installation process and are ready to use the Citus cluster. You can now login to the master node and start executing commands. The command below, when run in the psql shell, should output the worker nodes mentioned in the pg_dist_node.
 
 ::
 

--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -81,24 +81,23 @@ The steps listed below must be executed **only** on the master node after the pr
 
 **1. Add worker node information**
 
-We need to inform the master about its workers. To add this information, we append the worker database names and server ports to the `pg_worker_list.conf` file in the data directory. For our example, we assume that there are two workers (named worker-101, worker-102). Add the workers' DNS names and server ports to the list.
+We need to inform the master about its workers. To add this information, we call
+a UDF which adds the node information to the pg_dist_node catalog table. For our
+example, we assume that there are two workers (named worker-101,
+worker-102). Add the workers' DNS names and server ports to the table.
 
 ::
 
-  echo "worker-101 5432" | sudo -u postgres tee -a /var/lib/postgresql/9.5/main/pg_worker_list.conf
-  echo "worker-102 5432" | sudo -u postgres tee -a /var/lib/postgresql/9.5/main/pg_worker_list.conf
+  sudo -i -u postgres psql -c "SELECT master_add_node('worker-101', 5432);"
+  sudo -i -u postgres psql -c "SELECT master_add_node('worker-102', 5432);" 
 
 Note that you can also add this information by editing the file using your favorite editor.
 
-**2. Reload master database settings**
+**2. Verify that installation has succeeded**
 
-::
-
-  sudo service postgresql reload
-
-**3. Verify that installation has succeeded**
-
-To verify that the installation has succeeded, we check that the master node has picked up the desired worker configuration. This command when run in the psql shell should output the worker nodes mentioned in the `pg_worker_list.conf` file.
+To verify that the installation has succeeded, we check that the master node has
+picked up the desired worker configuration. This command when run in the psql
+shell should output the worker nodes we added to the pg_dist_node table above.
 
 ::
 

--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -88,8 +88,8 @@ worker-102). Add the workers' DNS names and server ports to the table.
 
 ::
 
-  sudo -i -u postgres psql -c "SELECT master_add_node('worker-101', 5432);"
-  sudo -i -u postgres psql -c "SELECT master_add_node('worker-102', 5432);" 
+  sudo -i -u postgres psql -c "SELECT * from master_add_node('worker-101', 5432);"
+  sudo -i -u postgres psql -c "SELECT * from master_add_node('worker-102', 5432);" 
 
 Note that you can also add this information by editing the file using your favorite editor.
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -88,7 +88,8 @@ The steps listed below must be executed **only** on the master node after the pr
 **1. Add worker node information**
 
 We need to inform the master about its workers. To add this information, we call
-a UDF which adds the node information to the pg_dist_node catalog table. For our
+a UDF which adds the node information to the pg_dist_node catalog table, which
+the master uses to get the list of worker nodes. For our
 example, we assume that there are two workers (named worker-101,
 worker-102). Add the workers' DNS names and server ports to the table.
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -95,8 +95,8 @@ worker-102). Add the workers' DNS names and server ports to the table.
 
 ::
 
-  sudo -i -u postgres psql -c "SELECT master_add_node('worker-101', 5432);"
-  sudo -i -u postgres psql -c "SELECT master_add_node('worker-102', 5432);" 
+  sudo -i -u postgres psql -c "SELECT * from master_add_node('worker-101', 5432);"
+  sudo -i -u postgres psql -c "SELECT * from master_add_node('worker-102', 5432);" 
 
 Note that you can also add this information by editing the file using your favorite editor.
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -87,24 +87,23 @@ The steps listed below must be executed **only** on the master node after the pr
 
 **1. Add worker node information**
 
-We need to inform the master about its workers. To add this information, we append the worker database names and server ports to the `pg_worker_list.conf` file in the data directory. For our example, we assume that there are two workers (named worker-101, worker-102). Add the workers' DNS names and server ports to the list.
+We need to inform the master about its workers. To add this information, we call
+a UDF which adds the node information to the pg_dist_node catalog table. For our
+example, we assume that there are two workers (named worker-101,
+worker-102). Add the workers' DNS names and server ports to the table.
 
 ::
 
-  echo "worker-101 5432" | sudo -u postgres tee -a /var/lib/pgsql/9.5/data/pg_worker_list.conf
-  echo "worker-102 5432" | sudo -u postgres tee -a /var/lib/pgsql/9.5/data/pg_worker_list.conf
+  sudo -i -u postgres psql -c "SELECT master_add_node('worker-101', 5432);"
+  sudo -i -u postgres psql -c "SELECT master_add_node('worker-102', 5432);" 
 
 Note that you can also add this information by editing the file using your favorite editor.
 
-**2. Reload master database settings**
+**2. Verify that installation has succeeded**
 
-::
-
-  sudo service postgresql-9.5 reload
-
-**3. Verify that installation has succeeded**
-
-To verify that the installation has succeeded, we check that the master node has picked up the desired worker configuration. This command when run in the psql shell should output the worker nodes mentioned in the `pg_worker_list.conf` file.
+To verify that the installation has succeeded, we check that the master node has
+picked up the desired worker configuration. This command when run in the psql
+shell should output the worker nodes we added to the pg_dist_node table above.
 
 ::
 

--- a/installation/single_machine_deb.rst
+++ b/installation/single_machine_deb.rst
@@ -50,7 +50,7 @@ Citus is a Postgres extension, to tell Postgres to use this extension you'll nee
 
 **3. Start the master and workers**
 
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+We will start the PostgreSQL instances on ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
 
 Let's start the databases::
 
@@ -71,8 +71,8 @@ Finally, the master needs to know where it can find the workers. To tell it you 
 
 ::
 
-  psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
-  psql -p 9700 -c "SELECT master_add_node('localhost', 9702);"
+  psql -p 9700 -c "SELECT * from master_add_node('localhost', 9701);"
+  psql -p 9700 -c "SELECT * from master_add_node('localhost', 9702);"
 
 **4. Verify that installation has succeeded**
 

--- a/installation/single_machine_deb.rst
+++ b/installation/single_machine_deb.rst
@@ -50,13 +50,14 @@ Citus is a Postgres extension, to tell Postgres to use this extension you'll nee
 
 **3. Start the master and workers**
 
+We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+
 Let's start the databases::
 
   pg_ctl -D citus/master -o "-p 9700" -l master_logfile start
   pg_ctl -D citus/worker1 -o "-p 9701" -l worker1_logfile start
   pg_ctl -D citus/worker2 -o "-p 9702" -l worker2_logfile start
 
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
 
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some deep parts of Postgres, swapping out the query planner and executor.  Here, we load the user-facing side of Citus (such as the functions you'll soon call):
 
@@ -66,7 +67,7 @@ Above you added Citus to ``shared_preload_libraries``. That lets it hook into so
   psql -p 9701 -c "CREATE EXTENSION citus;"
   psql -p 9702 -c "CREATE EXTENSION citus;"
 
-The master needs to know where it can find the workers. To tell it you can run:
+Finally, the master needs to know where it can find the workers. To tell it you can run:
 
 ::
 

--- a/installation/single_machine_deb.rst
+++ b/installation/single_machine_deb.rst
@@ -40,15 +40,6 @@ Let's create directories for those nodes to store their data. For convenience in
   initdb -D citus/worker1
   initdb -D citus/worker2
 
-The master needs to know where it can find the workers. To tell it you can run:
-
-::
-
-  echo "localhost 9701" >> citus/master/pg_worker_list.conf
-  echo "localhost 9702" >> citus/master/pg_worker_list.conf
-
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
-
 Citus is a Postgres extension, to tell Postgres to use this extension you'll need to add it to a configuration variable called ``shared_preload_libraries``:
 
 ::
@@ -65,6 +56,8 @@ Let's start the databases::
   pg_ctl -D citus/worker1 -o "-p 9701" -l worker1_logfile start
   pg_ctl -D citus/worker2 -o "-p 9702" -l worker2_logfile start
 
+We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some deep parts of Postgres, swapping out the query planner and executor.  Here, we load the user-facing side of Citus (such as the functions you'll soon call):
 
 ::
@@ -72,6 +65,13 @@ Above you added Citus to ``shared_preload_libraries``. That lets it hook into so
   psql -p 9700 -c "CREATE EXTENSION citus;"
   psql -p 9701 -c "CREATE EXTENSION citus;"
   psql -p 9702 -c "CREATE EXTENSION citus;"
+
+The master needs to know where it can find the workers. To tell it you can run:
+
+::
+
+  psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
+  psql -p 9700 -c "SELECT master_add_node('localhost', 9702);"
 
 **4. Verify that installation has succeeded**
 

--- a/installation/single_machine_osx.rst
+++ b/installation/single_machine_osx.rst
@@ -41,7 +41,7 @@ Citus is a Postgres extension, to tell Postgres to use this extension you'll nee
 
 **3. Start the master and workers**
 
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+We will start the PostgreSQL instances on ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
 
 Let's start the databases::
 
@@ -67,8 +67,8 @@ Finally, the master needs to know where it can find the workers. To tell it you 
 
 ::
 
-  psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
-  psql -p 9700 -c "SELECT master_add_node('localhost', 9702);"
+  psql -p 9700 -c "SELECT * from master_add_node('localhost', 9701);"
+  psql -p 9700 -c "SELECT * from master_add_node('localhost', 9702);"
 
 **4. Verify that installation has succeeded**
 

--- a/installation/single_machine_osx.rst
+++ b/installation/single_machine_osx.rst
@@ -41,6 +41,8 @@ Citus is a Postgres extension, to tell Postgres to use this extension you'll nee
 
 **3. Start the master and workers**
 
+We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+
 Let's start the databases::
 
   pg_ctl -D citus/master -o "-p 9700" -l master_logfile start
@@ -53,8 +55,6 @@ And initialize them::
   createdb -p 9701 $(whoami)
   createdb -p 9702 $(whoami)
 
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
-
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some deep parts of Postgres, swapping out the query planner and executor.  Here, we load the user-facing side of Citus (such as the functions you'll soon call):
 
 ::
@@ -63,7 +63,7 @@ Above you added Citus to ``shared_preload_libraries``. That lets it hook into so
   psql -p 9701 -c "CREATE EXTENSION citus;"
   psql -p 9702 -c "CREATE EXTENSION citus;"
 
-The master needs to know where it can find the workers. To tell it you can run:
+Finally, the master needs to know where it can find the workers. To tell it you can run:
 
 ::
 

--- a/installation/single_machine_osx.rst
+++ b/installation/single_machine_osx.rst
@@ -31,15 +31,6 @@ Let's create directories for those nodes to store their data. For convenience we
   initdb -D citus/worker1
   initdb -D citus/worker2
 
-The master needs to know where it can find the workers. To tell it you can run:
-
-::
-
-  echo "localhost 9701" >> citus/master/pg_worker_list.conf
-  echo "localhost 9702" >> citus/master/pg_worker_list.conf
-
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
-
 Citus is a Postgres extension, to tell Postgres to use this extension you'll need to add it to a configuration variable called ``shared_preload_libraries``:
 
 ::
@@ -62,6 +53,8 @@ And initialize them::
   createdb -p 9701 $(whoami)
   createdb -p 9702 $(whoami)
 
+We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some deep parts of Postgres, swapping out the query planner and executor.  Here, we load the user-facing side of Citus (such as the functions you'll soon call):
 
 ::
@@ -69,6 +62,13 @@ Above you added Citus to ``shared_preload_libraries``. That lets it hook into so
   psql -p 9700 -c "CREATE EXTENSION citus;"
   psql -p 9701 -c "CREATE EXTENSION citus;"
   psql -p 9702 -c "CREATE EXTENSION citus;"
+
+The master needs to know where it can find the workers. To tell it you can run:
+
+::
+
+  psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
+  psql -p 9700 -c "SELECT master_add_node('localhost', 9702);"
 
 **4. Verify that installation has succeeded**
 

--- a/installation/single_machine_rhel.rst
+++ b/installation/single_machine_rhel.rst
@@ -49,13 +49,14 @@ Citus is a Postgres extension, to tell Postgres to use this extension you'll nee
 
 **3. Start the master and workers**
 
+We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+
 Let's start the databases::
 
   pg_ctl -D citus/master -o "-p 9700" -l master_logfile start
   pg_ctl -D citus/worker1 -o "-p 9701" -l worker1_logfile start
   pg_ctl -D citus/worker2 -o "-p 9702" -l worker2_logfile start
 
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
 
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some deep parts of Postgres, swapping out the query planner and executor.  Here, we load the user-facing side of Citus (such as the functions you'll soon call):
 
@@ -65,7 +66,7 @@ Above you added Citus to ``shared_preload_libraries``. That lets it hook into so
   psql -p 9701 -c "CREATE EXTENSION citus;"
   psql -p 9702 -c "CREATE EXTENSION citus;"
 
-The master needs to know where it can find the workers. To tell it you can run:
+Finally, the master needs to know where it can find the workers. To tell it you can run:
 
 ::
 

--- a/installation/single_machine_rhel.rst
+++ b/installation/single_machine_rhel.rst
@@ -39,15 +39,6 @@ Let's create directories for those nodes to store their data. For convenience in
   initdb -D citus/worker1
   initdb -D citus/worker2
 
-The master needs to know where it can find the workers. To tell it you can run:
-
-::
-
-  echo "localhost 9701" >> citus/master/pg_worker_list.conf
-  echo "localhost 9702" >> citus/master/pg_worker_list.conf
-
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
-
 Citus is a Postgres extension, to tell Postgres to use this extension you'll need to add it to a configuration variable called ``shared_preload_libraries``:
 
 ::
@@ -64,6 +55,8 @@ Let's start the databases::
   pg_ctl -D citus/worker1 -o "-p 9701" -l worker1_logfile start
   pg_ctl -D citus/worker2 -o "-p 9702" -l worker2_logfile start
 
+We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some deep parts of Postgres, swapping out the query planner and executor.  Here, we load the user-facing side of Citus (such as the functions you'll soon call):
 
 ::
@@ -71,6 +64,13 @@ Above you added Citus to ``shared_preload_libraries``. That lets it hook into so
   psql -p 9700 -c "CREATE EXTENSION citus;"
   psql -p 9701 -c "CREATE EXTENSION citus;"
   psql -p 9702 -c "CREATE EXTENSION citus;"
+
+The master needs to know where it can find the workers. To tell it you can run:
+
+::
+
+  psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
+  psql -p 9700 -c "SELECT master_add_node('localhost', 9702);"
 
 **4. Verify that installation has succeeded**
 

--- a/installation/single_machine_rhel.rst
+++ b/installation/single_machine_rhel.rst
@@ -49,7 +49,7 @@ Citus is a Postgres extension, to tell Postgres to use this extension you'll nee
 
 **3. Start the master and workers**
 
-We will configure the PostgreSQL instances to use ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
+We will start the PostgreSQL instances on ports 9700 (for the master) and 9701, 9702 (for the workers). We assume those ports are available on your machine. Feel free to use different ports if they are in use.
 
 Let's start the databases::
 
@@ -70,8 +70,8 @@ Finally, the master needs to know where it can find the workers. To tell it you 
 
 ::
 
-  psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
-  psql -p 9700 -c "SELECT master_add_node('localhost', 9702);"
+  psql -p 9700 -c "SELECT * from master_add_node('localhost', 9701);"
+  psql -p 9700 -c "SELECT * from master_add_node('localhost', 9702);"
 
 **4. Verify that installation has succeeded**
 

--- a/reference/configuration.rst
+++ b/reference/configuration.rst
@@ -10,20 +10,6 @@ The rest of this reference aims at discussing Citus specific configuration param
 Node configuration
 ---------------------------------------
 
-pg_worker_list.conf
-$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-
-The Citus master needs to have information about the worker nodes in the cluster so that it can communicate with them. This information is stored in the pg_worker_list.conf file in the data directory on the master. To add this information, you need to append the DNS names and port numbers of the workers to this file. You can then call pg_reload_conf() or restart the master to allow it to refresh its worker membership list.
-
-The example below adds worker-101 and worker-102 as worker nodes in the pg_worker_list.conf file on the master.
-
-::
-
-	vi $PGDATA/pg_worker_list.conf
-	# HOSTNAME 	[PORT] 	[RACK]
-	worker-101
-	worker-102
-
 citus.max_worker_nodes_tracked (integer)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 

--- a/reference/metadata_tables.rst
+++ b/reference/metadata_tables.rst
@@ -24,7 +24,7 @@ The pg_dist_partition table stores metadata about which tables in the database a
 |   partkey      |         text         | | Detailed information about the distribution column including column     |
 |                |                      | | number, type and other relevant information.                            |
 +----------------+----------------------+---------------------------------------------------------------------------+
-|   colocationid |         integer      | | Colocation group to which this table belongs. Tables in the same group |
+|   colocationid |         integer      | | Colocation group to which this table belongs. Tables in the same group  |
 |                |                      | | allow colocated joins and distributed rollups among other               |
 |                |                      | | optimizations. This value references the colocationid column in the     |
 |                |                      | | pg_dist_colocation table.                                               |
@@ -176,6 +176,7 @@ Citus manages shard health on a per-placement basis and automatically marks a pl
 
 Worker node table
 ---------------------------------------
+.. _pg_dist_node:
 
 The pg_dist_node table contains information about the worker nodes in the cluster. 
 

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -345,7 +345,9 @@ Example
 master_get_active_worker_nodes
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-The master_get_active_worker_nodes() function returns a list of active worker host names and port numbers. Currently, the function assumes that all the worker nodes in pg_worker_list.conf are active.
+The master_get_active_worker_nodes() function returns a list of active worker
+host names and port numbers. Currently, the function assumes that all the worker
+nodes in the pg_dist_node catalog table are active.
 
 Arguments
 ************************

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -280,6 +280,8 @@ Example
 Metadata / Configuration Information
 ------------------------------------------------------------------------
 
+.. _master_add_node:
+
 master_add_node
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -307,10 +307,10 @@ Example
 
 ::
 
-    select master_add_node('new-node', 12345);
-            master_add_node         
-    --------------------------------
-     (5,5,new-node,12345,default,f)
+    select * from master_add_node('new-node', 12345);
+     nodeid | groupid | nodename | nodeport | noderack | hasmetadata 
+    --------+---------+----------+----------+----------+-------------
+          7 |       7 | new-node |    12345 | default  | f
     (1 row)
 
 master_remove_node

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -280,6 +280,68 @@ Example
 Metadata / Configuration Information
 ------------------------------------------------------------------------
 
+master_add_node
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+The master_add_node() function registers a new node addition in the cluster in
+the Citus metadata table pg_dist_node.
+
+Arguments
+************************
+
+**node_name:** DNS name of the new node to be added.
+
+**node_port:** The port on which PostgreSQL is listening on the worker node.
+
+Return Value
+******************************
+
+A tuple which represents a row from pg_dist_node table. See the metadata table
+reference section for more information on the table.
+
+
+Example
+***********************
+
+::
+
+    select master_add_node('new-node', 12345);
+            master_add_node         
+    --------------------------------
+     (5,5,new-node,12345,default,f)
+    (1 row)
+
+master_remove_node
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+The master_remove_node() function removes the specified node from the
+pg_dist_node metadata table. This function will error out if there are existing
+shard placements on this node in pg_dist_shard_placement. Thus, before using
+this function, the shards will need to be moved off that node.
+
+Arguments
+************************
+
+**node_name:** DNS name of the node to be removed.
+
+**node_port:** The port on which PostgreSQL is listening on the worker node.
+
+Return Value
+******************************
+
+N/A
+
+Example
+***********************
+
+::
+
+    select master_remove_node('new-node', 12345);
+     master_remove_node 
+    --------------------
+     
+    (1 row)
+
 master_get_active_worker_nodes
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -298,8 +298,8 @@ Arguments
 Return Value
 ******************************
 
-A tuple which represents a row from pg_dist_node table. See the metadata table
-reference section for more information on the table.
+A tuple which represents a row from :ref:`pg_dist_node
+<pg_dist_node>` table.
 
 
 Example

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -43,15 +43,6 @@ The above commands will give you warnings about trust authentication. Those
 will become important when you're setting up a production instance of Citus but
 for now you can safely ignore them.
 
-The master needs to know where it can find the worker. To tell it you can run:
-
-::
-
-  echo "localhost 9701" >> data/master/pg_worker_list.conf
-
-We assume that ports 9700 (for the master) and 9701 (for the worker) are
-available on your machine. Feel free to use different ports if they are in use.
-
 Citus is a Postgres extension. To tell Postgres to use this extension,
 you'll need to add it to a configuration variable called
 ``shared_preload_libraries``:
@@ -73,6 +64,9 @@ And initialize them::
   bin/createdb -p 9700 $(whoami)
   bin/createdb -p 9701 $(whoami)
 
+We assume that ports 9700 (for the master) and 9701 (for the worker) are
+available on your machine. Feel free to use different ports if they are in use.
+
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some
 deep parts of Postgres, swapping out the query planner and executor.  Here, we
 load the user-facing side of Citus (such as the functions you'll soon call):
@@ -81,6 +75,12 @@ load the user-facing side of Citus (such as the functions you'll soon call):
 
   bin/psql -p 9700 -c "CREATE EXTENSION citus;"
   bin/psql -p 9701 -c "CREATE EXTENSION citus;"
+
+Finally, the master needs to know where it can find the worker. To tell it you can run:
+
+::
+
+  bin/psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
 
 Ingest Data
 ===========

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -80,7 +80,7 @@ Finally, the master needs to know where it can find the worker. To tell it you c
 
 ::
 
-  bin/psql -p 9700 -c "SELECT master_add_node('localhost', 9701);"
+  bin/psql -p 9700 -c "SELECT * from master_add_node('localhost', 9701);"
 
 Ingest Data
 ===========

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -54,6 +54,9 @@ you'll need to add it to a configuration variable called
 
 **3. Start the master and worker**
 
+We assume that ports 9700 (for the master) and 9701 (for the worker) are
+available on your machine. Feel free to use different ports if they are in use.
+
 Let's start the databases::
 
   bin/pg_ctl -D data/master -o "-p 9700" -l master_logfile start
@@ -63,9 +66,6 @@ And initialize them::
 
   bin/createdb -p 9700 $(whoami)
   bin/createdb -p 9701 $(whoami)
-
-We assume that ports 9700 (for the master) and 9701 (for the worker) are
-available on your machine. Feel free to use different ports if they are in use.
 
 Above you added Citus to ``shared_preload_libraries``. That lets it hook into some
 deep parts of Postgres, swapping out the query planner and executor.  Here, we


### PR DESCRIPTION
Currently left upgrading Citus section as-is. This section will change anyway as we modify the upgrade instructions. We may additionally choose to keep the pg_worker_list.conf, and add information about it being marked as 'obsolete' in 6.0 after the first read.

This PR doesn't update Docker or the Cloud Formation template, so we'll need to split off separate items for those.

Fixes #179 