### PR TITLE
Remove documentation where we say Insert/Select isnt supported

### DIFF
--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -34,14 +34,12 @@ As the Citus master node is similar to a standard PostgreSQL server, regular Pos
 How do I ingest the results of a query into a distributed table?
 ----------------------------------------------------------------
 
-Citus currently doesn't support the INSERT / SELECT syntax for copying the results of a query into a distributed table. As a simple workaround, you could use
+Citus now supports the INSERT / SELECT syntax for copying the results of a query
+on a distributed table into a distributed table, when the tables are colocated.
 
-::
-
-  psql -c "COPY (query) TO STDOUT" | \
-  psql -c "COPY table FROM STDIN"
-
-In addition to the above, there are other workarounds which are more complex to implement but are more efficient. Please contact us if your use-case demands such ingest workflows.
+If your tables are not colocated, or you are using append distribution, there
+are workarounds which are more complex to implement. Please contact us if your
+use-case demands such ingest workflows.
 
 Can I join distributed and non-distributed tables together in the same query?
 -----------------------------------------------------------------------------

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -34,12 +34,13 @@ As the Citus master node is similar to a standard PostgreSQL server, regular Pos
 How do I ingest the results of a query into a distributed table?
 ----------------------------------------------------------------
 
-Citus now supports the INSERT / SELECT syntax for copying the results of a query
+Citus supports the `INSERT / SELECT <https://www.postgresql.org/docs/9.6/static/sql-insert.html>`_ syntax for copying the results of a query
 on a distributed table into a distributed table, when the tables are colocated.
 
 If your tables are not colocated, or you are using append distribution, there
-are workarounds which are more complex to implement. Please contact us if your
-use-case demands such ingest workflows.
+are workarounds you can use (for eg. using COPY to copy data out and then back
+into the destination table). Please contact us if your use-case demands such
+ingest workflows.
 
 Can I join distributed and non-distributed tables together in the same query?
 -----------------------------------------------------------------------------

--- a/reference/sql_workarounds.rst
+++ b/reference/sql_workarounds.rst
@@ -99,17 +99,6 @@ Interpolate the list of ids into a new query
    where page_id in (2,3,5,7,13)
   group by page_id
 
-INSERT INTO ... SELECT
-----------------------
-
-Citus does not support directly inserting the results of a query into a distributed table. One workaround is to use two database connections to stream the query results to master and then distribute them to the shards.
-
-.. code-block:: bash
-
-  psql -c "COPY (query) TO STDOUT" | psql -c "COPY table FROM STDIN"
-
-This does incur network cost. If this workaround is too slow please contact Citus Data support. We can assist you in parallelizing the table insertion across all workers using a more complicated technique.
-
 SELECT DISTINCT
 ---------------
 

--- a/tech_soln/real_time_dashboards.rst
+++ b/tech_soln/real_time_dashboards.rst
@@ -145,9 +145,7 @@ colocation; it makes queries such as joins faster and our rollups possible.
   :alt: colocation in citus
 
 In order to populate ``http_request_1min`` we're going to periodically run the equivalent
-of an INSERT INTO SELECT. Citus `doesn't yet support
-<https://github.com/citusdata/citus/issues/508>`_ INSERT INTO SELECT on distributed
-tables, so instead we'll run a function on all the workers which runs INSERT INTO SELECT
+of an INSERT INTO SELECT. We'll run a function on all the workers which runs INSERT INTO SELECT
 on every matching pair of shards. This is possible because the tables are colocated.
 
 .. code-block:: plpgsql


### PR DESCRIPTION
Remove notes where we say Insert-Into-Select isn't supported, as we support it 6.0 onwards. 

Fixes #196 