### PR TITLE
Post docker toolbox install

### DIFF
--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -7,42 +7,56 @@ This section describes setting up a Citus cluster on a single machine using dock
 
 **1. Install docker and docker-compose**
 
-The easiest way to install docker-compose on Mac or Windows is to use the `docker toolbox <https://www.docker.com/products/docker-toolbox>`_ installer. Ubuntu users can follow `this guide <https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-14-04>`_; other Linux distros have a similar procedure.
-
-Note that Docker runs in a virtual machine on Mac, and to use it in your terminal you first must run
-
-::
-
-	# for mac only
-	eval $(docker-machine env default)
-
-This exports environment variables which tell the docker command-line tools how to connect to the virtual machine.
+Follow the installation instructions for `Docker Engine <https://docs.docker.com/engine/installation/>`_ and `Docker Compose <https://docs.docker.com/compose/install/>`_ on your platform.
 
 **2. Start the Citus Cluster**
 
 Citus uses docker-compose to run and connect containers holding the database master node, workers, and a persistent data volume. To create a local cluster download our docker-compose configuration file and run it
 
-::
+.. code-block:: bash
 
-	wget https://raw.githubusercontent.com/citusdata/docker/master/docker-compose.yml
-	docker-compose -p citus up -d
+  wget https://raw.githubusercontent.com/citusdata/docker/master/docker-compose.yml
+  docker-compose -p citus up -d
 
-The first time you start the cluster it builds its containers. Subsequent startups take a
-matter of seconds.
+The first time you start the cluster it builds its containers. Subsequent startups take a matter of seconds.
+
+.. note::
+
+  If you have PostgreSQL running on your machine you may encounter this error when starting the Docker containers:
+
+  .. code::
+
+    Error starting userland proxy:
+    Bind for 0.0.0.0:5432: unexpected error address already in use
+
+  This is because the "master" service attempts to bind to the standard PostgreSQL port 5432. Simply adjust :code:`docker-compose.yml`. Under the :code:`master` section change the host port from 5432 to 5433 or another non-conflicting number.
+
+  .. code-block:: diff
+
+    - ports: ['5432:5432']
+    + ports: ['5433:5432']
 
 **3. Verify that installation has succeeded**
 
 
 To verify that the installation has succeeded we check that the master node has picked up the desired worker configuration. First start the psql shell on the master node:
 
-::
+.. code-block:: bash
 
-	docker exec -it citus_master psql -U postgres
+  docker exec -it citus_master psql -U postgres
 
 Then run this query:
 
-::
+.. code-block:: bash
 
-	select * from master_get_active_worker_nodes();
+  select * from master_get_active_worker_nodes();
 
 You should see a row for each worker node including the node name and port.
+
+**4. Shut down the cluster when ready**
+
+When you wish to stop the docker containers, use docker-compose:
+
+.. code-block:: bash
+
+  docker-compose -p citus down


### PR DESCRIPTION
Docker works natively nowadays on Windows and Mac. No more need for the Docker Toolbox VM. This PR fixes #138.
