### PR TITLE
Update discussions of rep factor default value

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -54,7 +54,14 @@ In this sub-section, we discuss how you can deal with node failures without incu
 Worker Node Failures
 --------------------
 
-Citus can easily tolerate worker node failures because of its logical sharding-based architecture. While loading data, Citus allows you to specify the replication factor to provide desired availability for your data. In face of worker node failures, Citus automatically switches to these replicas to serve your queries. It also issues warnings like below on the master so that users can take note of node failures and take actions accordingly.
+Citus can easily tolerate worker node failures because of its logical sharding-based architecture. While loading data, Citus allows you to specify the replication factor to provide desired availability for your data. The replication factor has a value of one by default, but can be set to two or higher for fault tolerance.
+
+.. code-block:: postgresql
+
+  SET citus.shard_replication_factor = 2;
+
+In face of worker node failures, Citus automatically switches to these replicas to serve your queries.
+It also issues warnings like below on the master so that users can take note of node failures and take actions accordingly.
 
 ::
 
@@ -74,6 +81,7 @@ make this simpler, Citus enterprise provides a replicate_table_shards UDF which
 can be called after. This function copies the shards of a table across the
 healthy nodes so they all reach the configured replication factor.
 
+
 To remove a permanently failed node from the list of workers, you should first
 mark all shard placements on that node as invalid (if they are not already so)
 using the following query:
@@ -85,7 +93,7 @@ using the following query:
 Then, you can remove the node using master_remove_node, as shown below:
 
 ::
-   
+
    select master_remove_node('bad-node-name', 5432);
 
 If you want to add a new node to the cluster to replace the

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -81,7 +81,6 @@ make this simpler, Citus enterprise provides a replicate_table_shards UDF which
 can be called after. This function copies the shards of a table across the
 healthy nodes so they all reach the configured replication factor.
 
-
 To remove a permanently failed node from the list of workers, you should first
 mark all shard placements on that node as invalid (if they are not already so)
 using the following query:

--- a/ref_arch/real_time_dashboards.rst
+++ b/ref_arch/real_time_dashboards.rst
@@ -30,8 +30,7 @@ all the details in one place. If you've followed our installation instructions f
 Citus on either a single or multiple machines you're ready to try it out.
 
 Data Model
-----------
-
+---------- 
 The data we're dealing with is an immutable stream of log data. We'll insert directly into
 Citus but it's also common for this data to first be routed through something like Kafka.
 Doing so has the usual advantages, and makes it easier to pre-aggregate the data once data
@@ -43,6 +42,7 @@ to demonstrate the overall architecture; a real system might use additional colu
 .. code-block:: sql
 
   -- this is run on the master
+
   CREATE TABLE http_request (
     site_id INT,
     ingest_time TIMESTAMPTZ DEFAULT now(),
@@ -55,16 +55,18 @@ to demonstrate the overall architecture; a real system might use additional colu
     response_time_msec INT
   );
 
+  SET citus.shard_replication_factor = 2;
+
   SELECT create_distributed_table('http_request', 'site_id');
 
 When we call :ref:`create_distributed_table <create_distributed_table>`
 we ask Citus to hash-distribute ``http_request`` using the ``site_id`` column. That means
 all the data for a particular site will live in the same shard.
 
-The UDF uses the default configuration values for shard count and replication
-factor. We recommend :ref:`using 2-4x as many shards <faq_choose_shard_count>`
-as CPU cores in your cluster. Using this many shards lets you rebalance data
-across your cluster after adding new worker nodes.
+The UDF uses the default configuration values for shard count. We
+recommend :ref:`using 2-4x as many shards <faq_choose_shard_count>` as
+CPU cores in your cluster. Using this many shards lets you rebalance
+data across your cluster after adding new worker nodes.
 
 Using a replication factor of 2 means every shard is held on multiple workers. When a
 worker fails the master will prevent downtime by serving queries for that worker's shards

--- a/ref_arch/real_time_dashboards.rst
+++ b/ref_arch/real_time_dashboards.rst
@@ -30,7 +30,8 @@ all the details in one place. If you've followed our installation instructions f
 Citus on either a single or multiple machines you're ready to try it out.
 
 Data Model
----------- 
+----------
+
 The data we're dealing with is an immutable stream of log data. We'll insert directly into
 Citus but it's also common for this data to first be routed through something like Kafka.
 Doing so has the usual advantages, and makes it easier to pre-aggregate the data once data

--- a/reference/append.rst
+++ b/reference/append.rst
@@ -157,7 +157,7 @@ Citus assigns a unique shard id to each new shard and all its replicas have the 
 By default, the \\copy command depends on two configuration parameters for its behavior. These are called citus.shard_max_size and citus.shard_replication_factor.
 
 (1) **citus.shard_max_size :-** This parameter determines the maximum size of a shard created using \\copy, and defaults to 1 GB. If the file is larger than this parameter, \\copy will break it up into multiple shards.
-(2) **citus.shard_replication_factor :-** This parameter determines the number of nodes each shard gets replicated to, and defaults to one. The ideal value for this parameter depends on the size of the cluster and rate of node failure. For example, you may want to increase the replication factor if you run large clusters and observe node failures on a more frequent basis.
+(2) **citus.shard_replication_factor :-** This parameter determines the number of nodes each shard gets replicated to, and defaults to one. Set it to two if you want Citus to replicate data automatically and provide fault tolerance. You may want to increase the factor even higher if you run large clusters and observe node failures on a more frequent basis.
 
 .. note::
     The configuration setting citus.shard_replication_factor can only be set on the master node.

--- a/reference/append.rst
+++ b/reference/append.rst
@@ -157,7 +157,7 @@ Citus assigns a unique shard id to each new shard and all its replicas have the 
 By default, the \\copy command depends on two configuration parameters for its behavior. These are called citus.shard_max_size and citus.shard_replication_factor.
 
 (1) **citus.shard_max_size :-** This parameter determines the maximum size of a shard created using \\copy, and defaults to 1 GB. If the file is larger than this parameter, \\copy will break it up into multiple shards.
-(2) **citus.shard_replication_factor :-** This parameter determines the number of nodes each shard gets replicated to, and defaults to two. The ideal value for this parameter depends on the size of the cluster and rate of node failure. For example, you may want to increase the replication factor if you run large clusters and observe node failures on a more frequent basis.
+(2) **citus.shard_replication_factor :-** This parameter determines the number of nodes each shard gets replicated to, and defaults to one. The ideal value for this parameter depends on the size of the cluster and rate of node failure. For example, you may want to increase the replication factor if you run large clusters and observe node failures on a more frequent basis.
 
 .. note::
     The configuration setting citus.shard_replication_factor can only be set on the master node.

--- a/reference/configuration.rst
+++ b/reference/configuration.rst
@@ -31,7 +31,7 @@ Sets the commit protocol to use when performing COPY on a hash distributed table
 citus.shard_replication_factor (integer)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-Sets the replication factor for shards i.e. the number of nodes on which shards will be placed and defaults to 2. This parameter can be set at run-time and is effective on the master.
+Sets the replication factor for shards i.e. the number of nodes on which shards will be placed and defaults to 1. This parameter can be set at run-time and is effective on the master.
 The ideal value for this parameter depends on the size of the cluster and rate of node failure. For example, you may want to increase this replication factor if you run large clusters and observe node failures on a more frequent basis.
 
 citus.shard_count (integer)

--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -135,8 +135,6 @@ should be distributed tables, stored across the cluster.
 
 .. code-block:: sql
 
-  SET citus.shard_replication_factor = 1;
-
   SELECT create_distributed_table('wikipedia_changes', 'editor');
   SELECT create_distributed_table('wikipedia_editors', 'editor');
 


### PR DESCRIPTION
Fixes #219

Note that the Cloud > Features > Replication Model section claims rep factor 2 is most popular. I left this unchanged, believing it has to do with streaming- rather than coordinator-replication.
