### PR TITLE
Tenant isolation

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -87,7 +87,7 @@ Tenant Isolation
 
 .. note::
 
-  Tenant isolation is a feature of **Citus Enterprise Edition** and :ref:`Citus Cloud <cloud>` only.
+  Tenant isolation is a feature of **Citus Enterprise Edition** and :ref:`Citus Cloud <cloud_overview>` only.
 
 Citus places table rows into worker shards based on the hashed value of the rows' distribution column. Multiple distribution column values often fall into the same shard. In the Citus multi-tenant use case this means that tenants often share shards.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -87,7 +87,7 @@ Tenant Isolation
 
 .. note::
 
-  Tenant isolation is a feature of **Citus Enterprise Edition** only.
+  Tenant isolation is a feature of **Citus Enterprise Edition** and :ref:`Citus Cloud <cloud>` only.
 
 Citus places table rows into worker shards based on the hashed value of the rows' distribution column. Multiple distribution column values often fall into the same shard. In the Citus multi-tenant use case this means that tenants often share shards.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -91,7 +91,9 @@ Tenant Isolation
 
 Citus places table rows into worker shards based on the hashed value of the rows' distribution column. Multiple distribution column values often fall into the same shard. In the Citus multi-tenant use case this means that tenants often share shards.
 
-Many multi-tenant SaaS providers face the problem that some tenants grow much bigger than the others, or require special resource guarantees. In Citus Enterprise Edition large tenants can be *isolated* to their own dedicated shards to better control the resource allocation between small and large tenants.
+However sharing shards can cause resource contention when tenants differ drastically in size. This is a common situation for systems with a large number of tenants -- we have observed that the size of tenant data tend to follow a Zipfian distribution as the number of tenants increases. This means there are a few very large tenants, and many smaller ones. To improve resource allocation and make guarantees of tenant QoS it is worthwhile to move large tenants to dedicated nodes.
+
+Citus Enterprise Edition and :ref:`Citus Cloud <cloud_overview>` provide the tools to isolate a tenant on a specific node. This happens in two phases: 1) isolating the tenant's data to a new dedicated shard, then 2) moving the shard to the desired node. To understand the process it helps to know precisely how rows of data are assigned to shards.
 
 Every shard is marked in Citus metadata with the range of hashed values it contains (more info in the reference for :ref:`pg_dist_shard <pg_dist_shard>`). The Citus UDF :code:`isolate_tenant_to_new_shard(table_name, tenant_id)` moves a tenant into a dedicated shard in three steps:
 

--- a/reference/metadata_tables.rst
+++ b/reference/metadata_tables.rst
@@ -45,6 +45,7 @@ The pg_dist_partition table stores metadata about which tables in the database a
      github_events | h          | {VAR :varno 1 :varattno 4 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 4 :location -1} |            2 | c
      (1 row)
 
+.. _pg_dist_shard:
 
 Shard table
 -----------------


### PR DESCRIPTION
One question. When I talk about the benefits for noisy neighbors etc, those benefits will be realized only after calling `master_move_shard_placement` to get the isolated shard onto its own node. Should I add details about that other UDF here as well?