### PR TITLE
Update tutorials to Citus 6.1

### DIFF
--- a/tutorials/tut-hash-distribution.rst
+++ b/tutorials/tut-hash-distribution.rst
@@ -14,9 +14,9 @@ To do the tutorial you'll need a single-machine Citus cluster with a master and 
 .. raw:: html 
 
   <ul>
-  <li> OS X Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.3.1.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.3.1.tar.gz'); return false;">Download</a>
+  <li> OS X Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.3.2.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-osx-1.3.2.tar.gz'); return false;">Download</a>
   </li>
-  <li> Linux Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.3.1.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.3.1.tar.gz'); return false;">Download</a>
+  <li> Linux Package: <a href="https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.3.2.tar.gz" onclick="trackOutboundLink('https://packages.citusdata.com/tutorials/citus-tutorial-linux-1.3.2.tar.gz'); return false;">Download</a>
   </li>
   </ul>
 


### PR DESCRIPTION
Built new binaries using Citus v6.1.0-rc2 and added them to S3. Tested tutorial instructions on OS X and Ubuntu.