### PR TITLE
Update docker instructions

### DIFF
--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -8,9 +8,11 @@ This section describes setting up a Citus cluster on a single machine using dock
 **1. Install docker and docker-compose**
 
 * Install the `Docker Platform <https://www.docker.com/products/overview#/install_the_platform>`_.
-* On most platforms this will install docker-compose as well, but on Linux you'll need to install docker-compose manually by downloading the binary and putting it in your path:
+* (Linux only) On most platforms the previous step will install docker-compose as well as Docker, but on Linux you'll need to install docker-compose manually by downloading the binary and putting it in your path:
 
   .. code-block:: bash
+
+    # Linux ONLY
 
     curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
     chmod +x /usr/local/bin/docker-compose

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -7,7 +7,13 @@ This section describes setting up a Citus cluster on a single machine using dock
 
 **1. Install docker and docker-compose**
 
-Follow the installation instructions for `Docker Engine <https://docs.docker.com/engine/installation/>`_ and `Docker Compose <https://docs.docker.com/compose/install/>`_ on your platform.
+* Install the `Docker Platform <https://www.docker.com/products/overview#/install_the_platform>`_.
+* On most platforms this will install docker-compose as well, but on Linux you'll need to install docker-compose manually by downloading the binary and putting it in your path:
+
+  .. code-block:: bash
+
+    curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
 
 **2. Start the Citus Cluster**
 

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -21,7 +21,7 @@ Citus uses docker-compose to run and connect containers holding the database mas
 
 .. code-block:: bash
 
-  wget https://raw.githubusercontent.com/citusdata/docker/master/docker-compose.yml
+  curl -L https://raw.githubusercontent.com/citusdata/docker/master/docker-compose.yml > docker-compose.yml
   docker-compose -p citus up -d
 
 The first time you start the cluster it builds its containers. Subsequent startups take a matter of seconds.

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -20,7 +20,7 @@ Linux
 .. code-block:: bash
 
   curl -sSL https://get.docker.com/ | sudo bash
-  sudo usermod -aG docker $USER && exec su -l $USER
+  sudo usermod -aG docker $USER && newgrp docker
   sudo systemctl start docker
 
   sudo curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -21,6 +21,7 @@ Linux
 
   curl -sSL https://get.docker.com/ | sudo bash
   sudo usermod -aG docker $USER && exec su -l $USER
+  sudo systemctl start docker
 
   sudo curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
   sudo chmod +x /usr/local/bin/docker-compose

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -5,27 +5,30 @@ Docker
 
 This section describes setting up a Citus cluster on a single machine using docker-compose.
 
-**1. Install docker and docker-compose**
+1. Install Docker Engine and docker-compose
+-------------------------------------------
+
+Mac / Windows
+~~~~~~~~~~~~~
 
 * Install the `Docker Platform <https://www.docker.com/products/overview#/install_the_platform>`_.
-* (Mac only) Start the Docker daemon
+* Start Docker by clicking on the application's icon.
 
-  .. code-block:: bash
+Linux
+~~~~~
 
-    # Mac ONLY
+.. code-block:: bash
 
-    open /Applications/Docker.app
+  curl -sSL https://get.docker.com/ | sudo bash
+  sudo usermod -aG docker $USER && exec su -l $USER
 
-* (Linux only) On most platforms the previous step will install docker-compose as well as Docker, but on Linux you'll need to install docker-compose manually by downloading the binary and putting it in your path:
+  sudo curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+  sudo chmod +x /usr/local/bin/docker-compose
 
-  .. code-block:: bash
+(This docker-compose version is fine for running Citus, or you can install the very latest version by following instructions `here <https://github.com/docker/compose/releases/latest>`_.)
 
-    # Linux ONLY
-
-    curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
-
-**2. Start the Citus Cluster**
+2. Start the Citus Cluster
+--------------------------
 
 Citus uses docker-compose to run and connect containers holding the database master node, workers, and a persistent data volume. To create a local cluster download our docker-compose configuration file and run it
 
@@ -38,7 +41,7 @@ The first time you start the cluster it builds its containers. Subsequent startu
 
 .. note::
 
-  If you have PostgreSQL running on your machine you may encounter this error when starting the Docker containers:
+  If you already have PostgreSQL running on your machine you may encounter this error when starting the Docker containers:
 
   .. code::
 
@@ -52,8 +55,8 @@ The first time you start the cluster it builds its containers. Subsequent startu
     - ports: ['5432:5432']
     + ports: ['5433:5432']
 
-**3. Verify that installation has succeeded**
-
+3. Verify that installation has succeeded
+-----------------------------------------
 
 To verify that the installation has succeeded we check that the master node has picked up the desired worker configuration. First start the psql shell on the master node:
 
@@ -72,7 +75,8 @@ You should see a row for each worker node including the node name and port.
 Once you have the cluster up and running, you can visit our :ref:`multi-tenant tutorial <multi_tenant_tutorial>` to
 get started with a sample dataset on Citus in minutes.
 
-**4. Shut down the cluster when ready**
+4. Shut down the cluster when ready
+-----------------------------------
 
 When you wish to stop the docker containers, use docker-compose:
 

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -8,8 +8,8 @@ This section describes setting up a Citus cluster on a single machine using dock
 1. Install Docker Engine and docker-compose
 -------------------------------------------
 
-Mac / Windows
-~~~~~~~~~~~~~
+Mac
+~~~
 
 * Install the `Docker Platform <https://www.docker.com/products/overview#/install_the_platform>`_.
 * Start Docker by clicking on the application's icon.
@@ -26,7 +26,7 @@ Linux
   sudo curl -L https://github.com/docker/compose/releases/download/1.11.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
   sudo chmod +x /usr/local/bin/docker-compose
 
-(This docker-compose version is fine for running Citus, or you can install the very latest version by following instructions `here <https://github.com/docker/compose/releases/latest>`_.)
+(This docker-compose version is fine for running Citus, or you can install the latest version by following instructions `here <https://github.com/docker/compose/releases/latest>`_.)
 
 2. Start the Citus Cluster
 --------------------------

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -8,6 +8,14 @@ This section describes setting up a Citus cluster on a single machine using dock
 **1. Install docker and docker-compose**
 
 * Install the `Docker Platform <https://www.docker.com/products/overview#/install_the_platform>`_.
+* (Mac only) Start the Docker daemon
+
+  .. code-block:: bash
+
+    # Mac ONLY
+
+    open /Applications/Docker.app
+
 * (Linux only) On most platforms the previous step will install docker-compose as well as Docker, but on Linux you'll need to install docker-compose manually by downloading the binary and putting it in your path:
 
   .. code-block:: bash


### PR DESCRIPTION
Fixes #292 (I will subsequently open a pull request to update the Citus readme as well).

Tested the Docker installation instructions under Ubuntu 16.04 and CentOS 7.3.