### PR TITLE
Document get_shard_id_for_distribution_column

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -145,3 +145,32 @@ The new shard(s) are created on the same node as the shard(s) from which the ten
     102240,
     'source_host', source_port,
     'dest_host', dest_port);
+
+Diagnostics
+###########
+
+.. _row_placements:
+
+Finding Row Placements
+----------------------
+
+Each row of a distributed table is assigned to a shard, and that shard is placed on a worker node in the Citus cluster. To determine which worker node contains a specific row, we put together two pieces of information: the :ref:`shard id <get_shard_id>` associated with the row's distribution column value, and the shard placements on workers. We can combine this into a single query. Here is how to find the placement of a row of :code:`my_table` whose distribution column has value 4:
+
+.. code-block:: postgresql
+
+  SELECT *
+    FROM pg_dist_shard_placement
+   WHERE shardid = (
+     SELECT get_shard_id_for_distribution_column('my_table', 4)
+   );
+
+The output contains the host and port of the worker database.
+
+::
+
+  ┌─────────┬────────────┬─────────────┬───────────┬──────────┬─────────────┐
+  │ shardid │ shardstate │ shardlength │ nodename  │ nodeport │ placementid │
+  ├─────────┼────────────┼─────────────┼───────────┼──────────┼─────────────┤
+  │  102009 │          1 │           0 │ localhost │     5433 │           2 │
+  └─────────┴────────────┴─────────────┴───────────┴──────────┴─────────────┘
+

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -151,17 +151,19 @@ Diagnostics
 
 .. _row_placements:
 
-Finding Row Placements
-----------------------
+Finding which shard contains data for a specific tenant
+-------------------------------------------------------
 
-Each row of a distributed table is assigned to a shard, and that shard is placed on a worker node in the Citus cluster. To determine which worker node contains a specific row, we put together two pieces of information: the :ref:`shard id <get_shard_id>` associated with the row's distribution column value, and the shard placements on workers. We can combine this into a single query. Here is how to find the placement of a row of :code:`my_table` whose distribution column has value 4:
+The rows of a distributed table are grouped into shards, and each shard is placed on a worker node in the Citus cluster. In the multi-tenant Citus use case we can determine which worker node contains the rows for a specific tenant by putting together two pieces of information: the :ref:`shard id <get_shard_id>` associated with the tenant id, and the shard placements on workers. The two can be retrieved together in a single query. Suppose our multi-tenant application's tenants and are stores, and we want to find which worker node holds the data for Gap.com (id=4, suppose).
+
+To find the worker node holding the data for store id=4, ask for the placement of rows whose distribution column has value 4:
 
 .. code-block:: postgresql
 
   SELECT *
     FROM pg_dist_shard_placement
    WHERE shardid = (
-     SELECT get_shard_id_for_distribution_column('my_table', 4)
+     SELECT get_shard_id_for_distribution_column('stores', 4)
    );
 
 The output contains the host and port of the worker database.

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -78,3 +78,8 @@ In which situations are uniqueness constraints supported on distributed tables?
 Citus is able to enforce a primary key or uniqueness constraint only when the constrained columns contain the distribution column. In particular this means that if a single column constitutes the primary key then it has to be the distribution column as well.
 
 This restriction allows Citus to localize a uniqueness check to a single shard and let PostgreSQL on the worker node do the check efficiently.
+
+How do I find which worker nodes contain which rows of a distributed table?
+---------------------------------------------------------------------------
+
+See :ref:`row_placements`.

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -79,7 +79,7 @@ Citus is able to enforce a primary key or uniqueness constraint only when the co
 
 This restriction allows Citus to localize a uniqueness check to a single shard and let PostgreSQL on the worker node do the check efficiently.
 
-How do I find which worker nodes contain which rows of a distributed table?
----------------------------------------------------------------------------
+Which shard contains data for a particular tenant?
+--------------------------------------------------
 
-See :ref:`row_placements`.
+Citus provides UDFs and metadata tables to determine the mapping of a distribution column value to a particular shard, and the shard placement on a worker node. See :ref:`row_placements` for more details.

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -426,6 +426,8 @@ The example below fetches and displays the table metadata for the github_events 
              24180 | t                 | h           | repo_id  |                  2 |    1073741824 |                     2
     (1 row)
 
+.. _get_shard_id:
+
 get_shard_id_for_distribution_column
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 

--- a/reference/user_defined_functions.rst
+++ b/reference/user_defined_functions.rst
@@ -426,6 +426,36 @@ The example below fetches and displays the table metadata for the github_events 
              24180 | t                 | h           | repo_id  |                  2 |    1073741824 |                     2
     (1 row)
 
+get_shard_id_for_distribution_column
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+Citus assigns every row of a distributed table to a shard based on the value of the row's distribution column and the table's method of distribution. In most cases the precise mapping is a low-level detail that the database administrator can ignore. However it can be useful to determine a row's shard, either for manual database maintenance tasks or just to satisfy curiosity. The :code:`get_shard_id_for_distribution_column` function provides this info for hash- and range-distributed tables as well as reference tables. It does not work for the append distribution.
+
+Arguments
+************************
+
+**table_name:** The distributed table.
+
+**distribution_value:** The value of the distribution column.
+
+Return Value
+******************************
+
+The shard id Citus associates with the distribution column value for the given table.
+
+Example
+***********************
+
+::
+
+  SELECT get_shard_id_for_distribution_column('my_table', 4);
+
+   get_shard_id_for_distribution_column
+  --------------------------------------
+                                 540007
+  (1 row)
+
+
 .. _cluster_management_functions:
 
 Cluster Management And Repair Functions


### PR DESCRIPTION
Fixes #225

I documented the function in the UDF reference section because I don't know a concrete activity or user goal that requires its use. If someone knows more about the context we can move my change to a more relevant part of the docs.