### PR TITLE
Move dataset pull from DDL to DML section where its used.

### DIFF
--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -10,13 +10,6 @@ Creating Distributed Tables (DDL)
 
         export PATH=/usr/lib/postgresql/9.6/:$PATH
 
-We use the github events dataset to illustrate the commands below. You can download that dataset by running:
-
-::
-
-    wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-{0..5}.csv.gz
-    gzip -d github_events-2015-01-01-*.gz
-
 Creating And Distributing Tables
 --------------------------------
 

--- a/dist_tables/dml.rst
+++ b/dist_tables/dml.rst
@@ -3,7 +3,7 @@
 Ingesting, Modifying Data (DML)
 ###############################
 
-The following code snippets use the distributed tables example, see :ref:`ddl`.
+The following code snippets use the Github events example, see :ref:`ddl`.
 
 Inserting Data
 --------------

--- a/dist_tables/dml.rst
+++ b/dist_tables/dml.rst
@@ -36,7 +36,7 @@ First download our example github_events dataset by running:
 
 Then, you can copy the data using psql:
 
-.. code-block:: sql
+.. code-block:: postgresql
 
     \COPY github_events FROM 'github_events-2015-01-01-0.csv' WITH (format CSV)
 

--- a/dist_tables/dml.rst
+++ b/dist_tables/dml.rst
@@ -3,7 +3,13 @@
 Ingesting, Modifying Data (DML)
 ###############################
 
-The following code snippets use the distributed tables example dataset, see :ref:`ddl`.
+The following code snippets use the distributed tables example, see :ref:`ddl`.
+We also use the github events dataset to illustrate the commands below. You can download that dataset by running:
+
+::
+
+    wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-{0..5}.csv.gz
+    gzip -d github_events-2015-01-01-*.gz
 
 Inserting Data
 --------------

--- a/dist_tables/dml.rst
+++ b/dist_tables/dml.rst
@@ -4,12 +4,6 @@ Ingesting, Modifying Data (DML)
 ###############################
 
 The following code snippets use the distributed tables example, see :ref:`ddl`.
-We also use the github events dataset to illustrate the commands below. You can download that dataset by running:
-
-::
-
-    wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-{0..5}.csv.gz
-    gzip -d github_events-2015-01-01-*.gz
 
 Inserting Data
 --------------
@@ -32,9 +26,17 @@ $$$$$$$$$$$$
 
 Sometimes, you may want to bulk load several rows together into your distributed tables. To bulk load data from a file, you can directly use `PostgreSQL's \\COPY command <http://www.postgresql.org/docs/current/static/app-psql.html#APP-PSQL-META-COMMANDS-COPY>`_.
 
-For example:
+First download our example github_events dataset by running:
 
-::
+.. code-block:: bash
+
+    wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-{0..5}.csv.gz
+    gzip -d github_events-2015-01-01-*.gz
+
+
+Then, you can copy the data using psql:
+
+.. code-block:: sql
 
     \COPY github_events FROM 'github_events-2015-01-01-0.csv' WITH (format CSV)
 


### PR DESCRIPTION
This had bugged me for a while, so opening a PR for it. Just moving the `wget` of the data files we use from DDL to DML where they are actually used in the `COPY` example.  The previous location was in the DDL section, where those files are never used.