### PR TITLE
Document DDL propagation

### DIFF
--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -148,3 +148,33 @@ You can use the standard PostgreSQL DROP TABLE command to remove your distribute
 ::
 
     DROP TABLE github_events;
+
+DDL Propagation
+---------------
+
+Modifying Tables
+~~~~~~~~~~~~~~~~
+
+  Y Adding a Column
+  Y Removing a Column
+      Except the dist column
+  Y Removing a Constraint
+      N Check Constraints
+          And gives an unpolished error (ERROR:  42704: constraint "http_request_1min_check_102104" of relation "http_request_1min_102104" does not exist)
+        Not-Null Constraints
+        Unique Constraints
+      Y Primary Keys
+      Y Foreign Keys
+  Y Adding a Constraint
+      N Check Constraints
+      Y Not-Null Constraints
+      N Unique Constraints
+      N Primary Keys
+      Y Foreign Keys
+          Watch out for lack of existing uniqueness constraints (ERROR:  42830: there is no unique constraint matching given keys for referenced table "http_request_102008")
+          Uniqueness cannot be propagated after distribution
+      Exclusion Constraints
+  Y Changing a Column's Default Value
+  Y Changing a Column's Data Type (except for dist column)
+  N Renaming a Column
+  N Renaming a Table

--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -272,7 +272,7 @@ Citus supports adding and removing `indices <https://www.postgresql.org/docs/cur
 Manual Modification
 ~~~~~~~~~~~~~~~~~~~
 
-If you attempt to alter a table and get an error such as "ERROR:  0A000: cannot create constraint," it means Citus does not yet support auto-propagation for the operation. In this case you can propagate the changes manually using this general four-step outline:
+Currently other DDL commands are not auto-propagated, however you can propagate the changes manually using this general four-step outline:
 
 1. Begin a transaction and take an ACCESS EXCLUSIVE lock on coordinator node against the table in question.
 2. In a separate connection, connect to each worker node and apply the operation to all shards.

--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -193,7 +193,9 @@ Adding Constraints
 |            |                      |                                                 |
 |            |                      | Add constraint before distributing!             |
 +------------+----------------------+-------------------------------------------------+
-| NO         | Unique Constraints   | Add constraint before distributing!             |
+| NO         | Unique Constraints   | Must include distribution column.               |
+|            |                      |                                                 |
+|            |                      | Add constraint before distributing!             |
 +------------+----------------------+-------------------------------------------------+
 | NO         | Check Constraints    |                                                 |
 +------------+----------------------+-------------------------------------------------+

--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -1,7 +1,7 @@
 .. _ddl:
 
-Creating Distributed Tables (DDL)
-#################################
+Creating and Modifying Distributed Tables (DDL)
+###############################################
 
 .. note::
     The instructions below assume that the PostgreSQL installation is in your path. If not, you will need to add it to your PATH environment variable. For example:
@@ -154,7 +154,7 @@ You can use the standard PostgreSQL DROP TABLE command to remove your distribute
 Modifying Tables
 ----------------
 
-Citus automatically propagates many kinds of DDL statements, which means that modifying a distributed table on the coordinator node will update shards on the workers too. Other DDL statements require manual propagation, and some others are prohibited such as those which would modify a distribution column. Attempting to run DDL that is ineligible for automatic propagation will raise an error and leave tables on the coordinator node unchanged. Additionally, some constraints like primary keys and uniqueness can only be applied prior to distributing a table.
+Citus automatically propagates many kinds of DDL statements, which means that modifying a distributed table on the coordinator node will update shards on the workers too. Other DDL statements require manual propagation, and certain others are prohibited such as those which would modify a distribution column. Attempting to run DDL that is ineligible for automatic propagation will raise an error and leave tables on the coordinator node unchanged. Additionally, some constraints like primary keys and uniqueness can only be applied prior to distributing a table.
 
 By default Citus performs DDL with a one-phase commit protocol. For greater safety you can enable two-phase commits by setting
 
@@ -164,32 +164,110 @@ By default Citus performs DDL with a one-phase commit protocol. For greater safe
 
 Here is a reference of the categories of DDL statements which propagate. Note that automatic propagation can be enabled or disabled with a :ref:`configuration parameter <enable_ddl_prop>`.
 
-* Table Columns
-    * Adding
-    * Changing default value
-    * Removing
-        * except the distribution column
-    * Changing data type
-        * except the distribution column
-    * Renaming
-        * except the distribution column
+Adding/Modifying Columns
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Adding/Removing Constraints
-    * Not-null
-    * Foreign keys
-        * must include distribution column
-        * requires uniqueness constraint on target column(s)
-    * Primary keys
-        * must include distribution column
-        * add constraint before distributing
-    * Uniqueness
-        * must include distribution column
-        * add constraint before distributing
+Citus propagates most `ALTER TABLE <https://www.postgresql.org/docs/current/static/ddl-alter.html>`_ commands automatically. Adding columns or changing their default values work as they would in a single-machine PostgreSQL database:
 
-* Indices
-    * Removing
-    * Adding
-        * Does not yet support CONCURRENTLY
+.. code-block:: postgresql
+
+  -- Adding a column
+
+  ALTER TABLE products ADD COLUMN description text;
+
+  -- Changing default value
+
+  ALTER TABLE products ALTER COLUMN price SET DEFAULT 7.77;
+
+Significant changes to an existing column are fine too, except for those applying to the :ref:`distribution column <distributed_data_modeling>`. This column determines how table data distributes through the Citus cluster and cannot be modified in a way that would change data distribution.
+
+
+.. code-block:: postgresql
+
+  -- Cannot be executed against a distribution column
+
+  -- Removing a column
+
+  ALTER TABLE products DROP COLUMN description;
+
+  -- Changing column data type
+
+  ALTER TABLE products ALTER COLUMN price TYPE numeric(10,2);
+
+  -- Renaming a column
+
+  ALTER TABLE products RENAME COLUMN product_no TO product_number;
+
+Adding/Removing Constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using Citus allows you to continue to enjoy the safety of a relational database, including database constraints (see the PostgreSQL `docs <https://www.postgresql.org/docs/current/static/ddl-constraints.html>`_). Due to the nature of distributed systems, Citus will not cross-reference uniqueness constraints or referential integrity between worker nodes. Foreign keys must always be declared between :ref:`colocated tables <colocation>`. To do this, use compound foreign keys that include the distribution column.
+
+This example, excerpted from a :ref:`typical_mt_schema`, shows how to create primary and foreign keys on distributed tables.
+
+.. code-block:: postgresql
+
+  --
+  -- Adding a primary key
+  -- --------------------
+
+  -- Ultimately we'll distribute these tables on the account id, so the
+  -- ads and clicks tables use compound keys to include it.
+
+  ALTER TABLE accounts ADD PRIMARY KEY (id);
+  ALTER TABLE ads ADD PRIMARY KEY (account_id, id);
+  ALTER TABLE clicks ADD PRIMARY KEY (account_id, id);
+
+  -- Next distribute the tables
+  -- (primary keys must be created prior to distribution)
+
+  SELECT create_distributed_table('accounts',  'id');
+  SELECT create_distributed_table('ads',       'account_id');
+  SELECT create_distributed_table('clicks',    'account_id');
+
+  --
+  -- Adding foreign keys
+  -- -------------------
+
+  -- Note that this can happen before or after distribution, as long as
+  -- there exists a uniqueness constraint on the target column(s) which
+  -- can only be enforced before distribution.
+
+  ALTER TABLE ads ADD CONSTRAINT ads_account_fk
+    FOREIGN KEY (account_id) REFERENCES accounts (id);
+  ALTER TABLE clicks ADD CONSTRAINT clicks_account_fk
+    FOREIGN KEY (account_id) REFERENCES accounts (id);
+
+Uniqueness constraints, like primary keys, must be added prior to table distribution.
+
+.. code-block:: postgresql
+
+  -- Suppose we want every ad to use a unique image. Notice we can
+  -- enforce it only per account when we distribute by account id.
+
+  ALTER TABLE ads ADD CONSTRAINT ads_unique_image
+    UNIQUE (account_id, image_url);
+
+Not-null constraints can always be applied because they require no lookups between workers.
+
+.. code-block:: postgresql
+
+  ALTER TABLE ads ALTER COLUMN image_url SET NOT NULL;
+
+Adding/Removing Indices
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Citus supports adding and removing `indices <https://www.postgresql.org/docs/current/static/sql-createindex.html>`_, but not with the :code:`CONCURRENTLY` option.
+
+.. code-block:: postgresql
+
+  -- Adding an index (does not support CONCURRENTLY)
+
+  CREATE INDEX clicked_at_idx ON clicks USING BRIN (clicked_at);
+
+  -- Removing an index
+
+  DROP INDEX clicked_at_idx;
 
 Manual Modification
 ~~~~~~~~~~~~~~~~~~~

--- a/reference/configuration.rst
+++ b/reference/configuration.rst
@@ -107,14 +107,14 @@ Use the binary copy format to transfer data between master and the workers. When
 DDL
 -------------------------------------------------------------------
 
+.. _enable_ddl_prop:
+
 citus.enable_ddl_propagation (boolean)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-Specifies whether to automatically propagate DDL changes from the master to all workers. The default value is true. Because some schema changes require an access exclusive lock on tables and because the automatic propagation applies to all workers sequentially it can make a Citus cluter temporarily less responsive. You may choose to disable this setting and propagate changes manually.
+Specifies whether to automatically propagate DDL changes from the master to all workers. The default value is true. Because some schema changes require an access exclusive lock on tables and because the automatic propagation applies to all workers sequentially it can make a Citus cluster temporarily less responsive. You may choose to disable this setting and propagate changes manually.
 
-.. note::
-
-  Currently CREATE INDEX and ALTER TABLE are the only DDL changes that Citus propagates automatically.
+For a list of DDL propagation support, see :ref:`ddl_prop_support`.
 
 Executor Configuration
 ------------------------------------------------------------

--- a/sharding/data_modeling.rst
+++ b/sharding/data_modeling.rst
@@ -38,6 +38,8 @@ To apply this design in your own schema the first step is identifying what const
 
 If you're migrating an existing database to the Citus multi-tenant architecture then some of your tables may lack a column for the application-specific tenant id. You will need to add one and fill it with the correct values. This will denormalize your tables slightly. For more details and a concrete example of backfilling the tenant id, see our guide to :ref:`Multi-Tenant Migration <transitioning_mt>`.
 
+.. _typical_mt_schema:
+
 Typical Multi-Tenant Schema
 ---------------------------
 


### PR DESCRIPTION
Fixes #159 

Note that `create index` is not listed as DDL in the PostgreSQL manual. Should I include `create index` along with my other additions in this section or in a new subsection of Querying Distributed Tables (SQL)? 