### PR TITLE
How to set auth methods for workers

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -165,12 +165,12 @@ Broadcasting a statement for execution on all workers is useful for viewing prop
 
 The :code:`run_command_on_workers` function can run only queries which return a single column and single row.
 
+.. _worker_security:
+
 Worker Security
 ###############
 
-For your convenience getting started, our multi-node installation instructions direct you to set up the :code:`pg_hba.conf` on the workers with its `authentication method <https://www.postgresql.org/docs/current/static/auth-methods.html>`_ set to "trust" for local network connections. This is also the default configuration on Citus Cloud. It offers reasonable security, but more may be desired.
-
-For instance, requiring roles and passwords for connection ensures that users must connect as only the roles permitted to them. This allows having users with read-only access, or hiding tables with sensitive information.
+For your convenience getting started, our multi-node installation instructions direct you to set up the :code:`pg_hba.conf` on the workers with its `authentication method <https://www.postgresql.org/docs/current/static/auth-methods.html>`_ set to "trust" for local network connections. However you might desire more security.
 
 To require that all connections supply a hashed password, update the PostgreSQL :code:`pg_hba.conf` on every worker node with something like this:
 

--- a/dist_tables/querying.rst
+++ b/dist_tables/querying.rst
@@ -99,6 +99,8 @@ To join two large tables efficiently, it is advised that you distribute them on 
 .. note::
   In order to benefit most from co-located joins, you should hash distribute your tables on the join key and use the same number of shards for both tables. If you do this, each shard will join with exactly one shard of the other table. Also, the shard creation logic will ensure that shards with the same distribution key ranges are on the same workers. This means no data needs to be transferred between the workers, leading to faster joins.
 
+.. _repartition_joins:
+
 Repartition joins
 ----------------------------
 

--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -54,7 +54,7 @@ Before starting the database let's change its access permissions. By default the
   host    all             all             ::1/128                 trust
 
 .. note::
-  Your DNS settings may differ. Also these settings are too permissive for some environments. The PostgreSQL manual `explains how <http://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html>`_ to make them more restrictive.
+  Your DNS settings may differ. Also these settings are too permissive for some environments, see our notes about :ref:`worker_security`. The PostgreSQL manual `explains how <http://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html>`_ to make them more restrictive.
 
 **4. Start database servers, create Citus extension**
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -61,7 +61,7 @@ Before starting the database let's change its access permissions. By default the
   host    all             all             ::1/128                 trust
 
 .. note::
-  Your DNS settings may differ. Also these settings are too permissive for some environments. The PostgreSQL manual `explains how <http://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html>`_ to make them more restrictive.
+  Your DNS settings may differ. Also these settings are too permissive for some environments, see our notes about :ref:`worker_security`. The PostgreSQL manual `explains how <http://www.postgresql.org/docs/9.6/static/auth-pg-hba-conf.html>`_ to make them more restrictive.
 
 **4. Start database servers, create Citus extension**
 


### PR DESCRIPTION
Fixes #350

I thought that the idea of worker permissions is relevant to more than just Cloud, so I added this to the general Cluster Administration section.

One thing that is lacking, however, is specific instructions for Cloud on how to ssh into the workers or scp the .pgpass and pg_hba.conf files into place. I actually don't know how to do this, perhaps I must ssh into the coordinator and from there into workers. Not sure. Is this something we should cover?