### PR TITLE
More visible suggestions for increasing insert speed

### DIFF
--- a/performance/scaling_data_ingestion.rst
+++ b/performance/scaling_data_ingestion.rst
@@ -30,6 +30,7 @@ To reach high throughput rates, remember these techniques:
 * Increase CPU cores and memory on the coordinator node. Inserted data must pass through the coordinator, so check whether node resources are maxing out and upgrade the hardware if necessary.
 * Ingest with more threads on the client. If you have determined that the coordinator has enough resources, then throughput may be bottlenecked on the client. Try sending using more threads and PostgreSQL connections.
 * Avoid closing connections between INSERT statements. This avoids the overhead of connection setup.
+* Remember that column size will affect insert speed. Rows with big JSON blobs will take longer than those with small columns like integers.
 
 Real-time Updates (0-50k/s)
 ---------------------------

--- a/performance/scaling_data_ingestion.rst
+++ b/performance/scaling_data_ingestion.rst
@@ -25,7 +25,11 @@ When processing an INSERT, Citus first finds the right shard placements based on
     INSERT INTO counters VALUES ('num_purchases', '2016-03-04', 12); -- Time: 10.314 ms
     INSERT INTO counters VALUES ('num_purchases', '2016-03-05', 5); -- Time: 3.132 ms
 
-To reach high throughput rates, applications should send INSERTs over a many separate connections and keep connections open to avoid the initial overhead of connection set-up.
+To reach high throughput rates, remember these techniques:
+
+* Increase CPU cores and memory on the coordinator node. Inserted data must pass through the coordinator, so check whether node resources are maxing out and upgrade the hardware if necessary.
+* Ingest with more threads on the client. If you have determined that the coordinator has enough resources, then throughput may be bottlenecked on the client. Try sending using more threads and PostgreSQL connections.
+* Avoid closing connections between INSERT statements. This avoids the overhead of connection setup.
 
 Real-time Updates (0-50k/s)
 ---------------------------


### PR DESCRIPTION
Fixes #351

I didn't see anything online about improving insert speed in Rails except for the bulk loading scenario. People recommend the activerecord-import gem, but that uses multiple values in a single insert statement which currently won't work. So maybe we can keep the list of tips application framework agnostic.