### PR TITLE
Include post-package installation links in install docs

### DIFF
--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -19,6 +19,8 @@ Steps to be executed on all nodes
   # Add Citus repository for package manager
   curl https://install.citusdata.com/community/deb.sh | sudo bash
 
+.. _post_install:
+
 **2. Install PostgreSQL + Citus and initialize a database**
 
 ::

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -19,6 +19,7 @@ Steps to be executed on all nodes
   # Add Citus repository for package manager
   curl https://install.citusdata.com/community/rpm.sh | sudo bash
 
+.. _post_install:
 
 **2. Install PostgreSQL + Citus and initialize a database**
 

--- a/installation/single_machine_deb.rst
+++ b/installation/single_machine_deb.rst
@@ -18,6 +18,8 @@ This section describes the steps needed to set up a single-node Citus cluster on
   sudo apt-get -y install postgresql-9.6-citus-6.1
 
 
+.. _post_install:
+
 **2. Initialize the Cluster**
 
 Citus has two kinds of components, the coordinator and the workers. The coordinator coordinates queries and maintains metadata on where in the cluster each row of data is. The workers hold your data and respond to queries.

--- a/installation/single_machine_docker.rst
+++ b/installation/single_machine_docker.rst
@@ -25,6 +25,8 @@ This section describes setting up a Citus cluster on a single machine using dock
 
 The above version of Docker Compose is sufficient for running Citus, or you can install the `latest version <https://github.com/docker/compose/releases/latest>`_.
 
+.. _post_install:
+
 **2. Start the Citus Cluster**
 
 Citus uses Docker Compose to run and connect containers holding the database coordinator node, workers, and a persistent data volume. To create a local cluster download our Docker Compose configuration file and run it

--- a/installation/single_machine_rhel.rst
+++ b/installation/single_machine_rhel.rst
@@ -17,6 +17,8 @@ This section describes the steps needed to set up a single-node Citus cluster on
   # install Citus extension
   sudo yum install -y citus61_96
 
+.. _post_install:
+
 **2. Initialize the Cluster**
 
 Citus has two kinds of components, the coordinator and the workers. The coordinator coordinates queries and maintains metadata on where in the cluster each row of data is. The workers hold your data and respond to queries.


### PR DESCRIPTION
@craigkerstiens this PR adds anchors at step two in the installation page for each type of installation.

A couple notes:
* Docker can be tricky to install, might want to continue linking to the start of the document
* Step 2 on some of these docs (like Debian) overlaps a little with the instructions in your download popup.
* The url fragment to add to your links is `#post-install`