### PR TITLE
Remove note from the DDL section

### DIFF
--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -3,13 +3,6 @@
 Creating and Modifying Distributed Tables (DDL)
 ###############################################
 
-.. note::
-    The instructions below assume that the PostgreSQL installation is in your path. If not, you will need to add it to your PATH environment variable. For example:
-
-    ::
-
-        export PATH=/usr/lib/postgresql/9.6/:$PATH
-
 Creating And Distributing Tables
 --------------------------------
 

--- a/dist_tables/ddl.rst
+++ b/dist_tables/ddl.rst
@@ -10,7 +10,6 @@ To create a distributed table, you need to first define the table schema. To do 
 
 ::
 
-    psql -h localhost -d postgres
     CREATE TABLE github_events
     (
     	event_id bigint,


### PR DESCRIPTION
We had a note in this section warning the user about setting their environment PATHs.

Is this note still relevant for the DDL section? Or should we move this warning to a different section?