### PR TITLE
Fix "Tutorial", and rename "Distributed Tables" section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -75,7 +75,7 @@ Welcome to the documentation for Citus 7.0! Citus horizontally scales PostgreSQL
    installation/production.rst
 
 .. toctree::
-   :caption: Tutorial
+   :caption: Tutorials
    :hidden:
 
    tutorials/multi-tenant-tutorial.rst
@@ -90,7 +90,7 @@ Welcome to the documentation for Citus 7.0! Citus horizontally scales PostgreSQL
 
 .. toctree::
    :maxdepth: 1
-   :caption: Distributed Tables
+   :caption: SQL Reference
    :hidden:
 
    dist_tables/ddl.rst

--- a/performance/scaling_data_ingestion.rst
+++ b/performance/scaling_data_ingestion.rst
@@ -92,7 +92,7 @@ The benefit of running INSERT or UPDATE commands, compared to issuing bulk COPY 
 .. _bulk_copy:
 
 Bulk Copy (250K - 2M/s)
-----------------------
+-----------------------
 
 Distributed tables support `COPY <http://www.postgresql.org/docs/current/static/sql-copy.html>`_ from the Citus coordinator for bulk ingestion, which can achieve much higher ingestion rates than INSERT statements.
 


### PR DESCRIPTION
Renamed Distributed Tables to SQL Reference. I think that's a reasonable enough name, and couldn't come up with anything more descriptive. Also makes us think about adding information on SQL support.

Also fixed "Tutorial".

Fixes #406 