### PR TITLE
Update nodeport to INT4

### DIFF
--- a/use_case_guide/real_time_dashboards.rst
+++ b/use_case_guide/real_time_dashboards.rst
@@ -191,7 +191,7 @@ its own function to figure that out:
 
     -- this function is created on the coordinator
     CREATE FUNCTION colocated_shard_placements(left_table REGCLASS, right_table REGCLASS)
-    RETURNS TABLE (left_shard TEXT, right_shard TEXT, nodename TEXT, nodeport BIGINT) AS $$
+    RETURNS TABLE (left_shard TEXT, right_shard TEXT, nodename TEXT, nodeport INT4) AS $$
       SELECT
         a.logicalrelid::regclass||'_'||a.shardid,
         b.logicalrelid::regclass||'_'||b.shardid,

--- a/use_case_guide/real_time_dashboards.rst
+++ b/use_case_guide/real_time_dashboards.rst
@@ -199,7 +199,7 @@ its own function to figure that out:
       FROM pg_dist_shard a
       JOIN pg_dist_shard b USING (shardminvalue)
       JOIN pg_dist_placement p ON (a.shardid = p.shardid)
-      JOIN pg_node n ON (p.groupid = n.groupid)
+      JOIN pg_dist_node n ON (p.groupid = n.groupid)
       WHERE a.logicalrelid = left_table AND b.logicalrelid = right_table;
     $$ LANGUAGE 'sql';
 


### PR DESCRIPTION
Fixes #444 

Nodeport type was updated from bigint to int4. The function errors out on Citus 7.0.