### PR TITLE
Remove tutorial links from multi-node install docs

### DIFF
--- a/installation/production_deb.rst
+++ b/installation/production_deb.rst
@@ -106,9 +106,7 @@ shell should output the worker nodes we added to the pg_dist_node table above.
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<multi_tenant_tutorial>` which has instructions on setting up a Citus cluster with sample data in minutes.
-
-Your new Citus database is accessible in psql through the postgres user:
+At this step, you have completed the installation process and are ready to use your Citus cluster. The new Citus database is accessible in psql through the postgres user:
 
 ::
 

--- a/installation/production_rhel.rst
+++ b/installation/production_rhel.rst
@@ -112,9 +112,7 @@ shell should output the worker nodes we added to the pg_dist_node table above.
 
 **Ready to use Citus**
 
-At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<multi_tenant_tutorial>` which has instructions on setting up a Citus cluster with sample data in minutes.
-
-Your new Citus database is accessible in psql through the postgres user:
+At this step, you have completed the installation process and are ready to use your Citus cluster. The new Citus database is accessible in psql through the postgres user:
 
 ::
 

--- a/installation/single_machine_deb.rst
+++ b/installation/single_machine_deb.rst
@@ -85,3 +85,5 @@ To verify that the installation has succeeded we check that the coordinator node
   psql -p 9700 -c "select * from master_get_active_worker_nodes();"
 
 You should see a row for each worker node including the node name and port.
+
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<multi_tenant_tutorial>` which has instructions on setting up a Citus cluster with sample data in minutes.

--- a/installation/single_machine_rhel.rst
+++ b/installation/single_machine_rhel.rst
@@ -84,3 +84,5 @@ To verify that the installation has succeeded we check that the coordinator node
   psql -p 9700 -c "select * from master_get_active_worker_nodes();"
 
 You should see a row for each worker node including the node name and port.
+
+At this step, you have completed the installation process and are ready to use your Citus cluster. To help you get started, we have a :ref:`tutorial<multi_tenant_tutorial>` which has instructions on setting up a Citus cluster with sample data in minutes.


### PR DESCRIPTION
Tutorials presuppose docker or cloud

Fixes #293 

I didn't need to add a link to tutorials from Docker install since they already exist. Adding a link from the Cloud section seemed out of place, but we can do it desired.