### PR TITLE
Improve usability of upgrade steps

### DIFF
--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -130,7 +130,9 @@ On the Coordinator Node
 
   * **DO NOT CREATE** Citus extension yet
 
-3. Stop the old and new servers.
+  * **DO NOT** start the new server
+
+3. Stop the old server.
 
 4. Check upgrade compatibility.
 
@@ -152,6 +154,8 @@ On the Coordinator Node
                                 -d $OLD_PG_DATA -D $NEW_PG_DATA
 
 6. Start the new server.
+
+  * **DO NOT** run any query before running the queries given in the next step
 
 7. Restore metadata.
 


### PR DESCRIPTION
Improvements on the usability of upgrade steps. 

If user either start the server before upgrading process or run any query before metadata restore, background daemon may wake up and log chunk of error/warning messages.