### PR TITLE
Move canonical link to very bottom of <head>

### DIFF
--- a/_themes/citus/layout.html
+++ b/_themes/citus/layout.html
@@ -23,11 +23,6 @@
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
   {% endif %}
 
-  {# ARTICLE CANONICAL URL #}
-  {% if pagename in canonical_urls %}
-    <link rel="canonical" href="{{ canonical_urls[pagename] }}" />
-  {% endif %}
-
   {# CSS #}
 
   {# OPENSEARCH #}
@@ -86,6 +81,15 @@
     analytics.load("TKfha8eC8r4TBLXXQhGyc6rmGud8nVa0");
     }}();
   </script>
+
+  {# ARTICLE CANONICAL URL
+
+     Put last in head to ensure it overrides whatever Read The Docs
+     wants to inject in this page.
+  #}
+  {% if pagename in canonical_urls %}
+    <link rel="canonical" href="{{ canonical_urls[pagename] }}" />
+  {% endif %}
 </head>
 
 <body class="wy-body-for-nav" role="document">


### PR DESCRIPTION
Read The Docs [adds a canonical link](https://docs.readthedocs.io/en/latest/canonical.html) to every page that in theory is supposed to point search engines to the latest existing version of each page. Turns out this link was overriding our custom canonical links for blog-posts-turned-docs-articles.

This PR simply moves our own link to the very bottom of the page `<head>`, giving it the final say.

Another observation: the RTD canonical links actually don't point at the latest version. Visiting each version of our docs homepage I found they create a chain like this:

```
5.0 -> 5.1
5.1 -> 5.2
5.2 -> 6.0
6.0 -> 6.1
6.1 -> 7.0
6.2 -> 7.0
7.0 -> 7.0
7.1 -> 7.1
```

After compiling that list, I triggered a rebuild of v7.0 and now its canonical link points at 7.1, showing that the link points to whatever version is newest at build time. Thus we should add a step to our release checklist to rebuild the prior version after deploying the new one, just to be sure it points at the newest version. We could consider rebuilding a few versions back too if desired, although over time they should all transitively point to the newest version.