### PR TITLE
Document citus.enable_repartition_joins

### DIFF
--- a/reference/configuration.rst
+++ b/reference/configuration.rst
@@ -244,6 +244,11 @@ Sets the maximum number of simultaneously open files for each server process and
 .. note::
   Along with max_files_per_process, one may also have to increase the kernel limit for open file descriptors per process using the ulimit command.
 
+citus.enable_repartition_joins (boolean)
+****************************************
+
+Ordinarily, attempting to perform :ref:`repartition_joins` with the real-time executor will fail with an error message. However setting ``citus.enable_repartition_joins`` to true allows Citus to temporarily switch into the task-tracker executor to perform the join. The default value is false.
+
 Task tracker executor configuration
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 

--- a/sharding/colocation.rst
+++ b/sharding/colocation.rst
@@ -91,7 +91,7 @@ Across all shards of the event table (Q2):
 
   SELECT page_id, count(*) AS count
   FROM event
-  WHERE page_id IN (…page IDs from first query…)
+  WHERE page_id IN (/*…page IDs from first query…*/)
     AND tenant_id = 6
     AND (payload->>'time')::date >= now() - interval '1 week'
   GROUP BY page_id ORDER BY count DESC LIMIT 10;


### PR DESCRIPTION
Fixes #583 

Also includes an unrelated change to remove a sphinx warning.