### PR TITLE
Update benchmark instructions

### DIFF
--- a/extra/write_throughput_benchmark.rst
+++ b/extra/write_throughput_benchmark.rst
@@ -37,14 +37,13 @@ Once we create a new EC2 instance, we need to install pgbench on this instance. 
 
 If you are running a **Debian** based system, simply type::
 
+  sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  sudo apt-get install wget ca-certificates
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   sudo apt-get update
   sudo apt-get install postgresql-10
 
-If you are running a **RedHat** based system, simply type::
-
-  sudo yum update
-  sudo yum install postgresql10-contrib
-
+If you are running a **RedHat** based system, follow the `yum installation guide <https://wiki.postgresql.org/wiki/YUM_Installation>`_.
 
 Benchmark INSERT Throughput
 ---------------------------

--- a/extra/write_throughput_benchmark.rst
+++ b/extra/write_throughput_benchmark.rst
@@ -43,7 +43,7 @@ If you are running a **Debian** based system, simply type::
   sudo apt-get update
   sudo apt-get install postgresql-10
 
-If you are running a **RedHat** based system, follow the `yum installation guide <https://wiki.postgresql.org/wiki/YUM_Installation>`_.
+If you are running a **RedHat** based system, follow the `yum installation guide <https://www.postgresql.org/download/linux/redhat/>`_.
 
 Benchmark INSERT Throughput
 ---------------------------

--- a/extra/write_throughput_benchmark.rst
+++ b/extra/write_throughput_benchmark.rst
@@ -41,9 +41,9 @@ If you are running a **Debian** based system, simply type::
   sudo apt-get install wget ca-certificates
   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   sudo apt-get update
-  sudo apt-get install postgresql-10
+  sudo apt-get install postgresql-client-10
 
-If you are running a **RedHat** based system, follow the `yum installation guide <https://wiki.postgresql.org/wiki/YUM_Installation>`_.
+If you are running a **RedHat** based system, follow the `yum installation guide <https://www.postgresql.org/download/linux/redhat/>`_ to install the PostgreSQL client programs, including pgbench.
 
 Benchmark INSERT Throughput
 ---------------------------

--- a/extra/write_throughput_benchmark.rst
+++ b/extra/write_throughput_benchmark.rst
@@ -35,15 +35,19 @@ Install pgbench
 
 Once we create a new EC2 instance, we need to install pgbench on this instance. Please note that pgbench 10 will run across all Citus versions and that the instructions below assume that you're using pgbench 10.
 
-If you are running a **Debian** based system, simply type::
+* For **Debian** based system:
 
-  sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-  sudo apt-get install wget ca-certificates
-  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  sudo apt-get update
-  sudo apt-get install postgresql-10
+  .. code-block:: bash
 
-If you are running a **RedHat** based system, follow the `yum installation guide <https://www.postgresql.org/download/linux/redhat/>`_.
+    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+    sudo apt-get install wget ca-certificates
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+    sudo apt-get update
+    sudo apt-get install postgresql-10
+
+* For **RedHat** based system:
+
+  Follow the `yum installation guide <https://www.postgresql.org/download/linux/redhat/>`_.
 
 Benchmark INSERT Throughput
 ---------------------------

--- a/extra/write_throughput_benchmark.rst
+++ b/extra/write_throughput_benchmark.rst
@@ -41,9 +41,9 @@ If you are running a **Debian** based system, simply type::
   sudo apt-get install wget ca-certificates
   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   sudo apt-get update
-  sudo apt-get install postgresql-client-10
+  sudo apt-get install postgresql-10
 
-If you are running a **RedHat** based system, follow the `yum installation guide <https://www.postgresql.org/download/linux/redhat/>`_ to install the PostgreSQL client programs, including pgbench.
+If you are running a **RedHat** based system, follow the `yum installation guide <https://wiki.postgresql.org/wiki/YUM_Installation>`_.
 
 Benchmark INSERT Throughput
 ---------------------------


### PR DESCRIPTION
Pg 10 hasn't made it into many debian or rhel based distros. This updates the steps to use PGDG for the install.

Fixes #589