### PR TITLE
Publicize manual query propagation

### DIFF
--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -303,11 +303,4 @@ Adding an index takes a write lock, which can be undesirable in a multi-tenant "
 Manual Modification
 ~~~~~~~~~~~~~~~~~~~
 
-Currently other DDL commands are not auto-propagated, however you can propagate the changes manually using this general four-step outline:
-
-1. Begin a transaction and take an ACCESS EXCLUSIVE lock on coordinator node against the table in question.
-2. In a separate connection, connect to each worker node and apply the operation to all shards.
-3. Disable DDL propagation on the coordinator and run the DDL command there.
-4. Commit the transaction (which will release the lock).
-
-Contact us for guidance about the process, we have internal tools which can make it easier.
+Currently other DDL commands are not auto-propagated, however you can propagate the changes manually. See :ref:`manual_prop`.

--- a/develop/reference_propagation.rst
+++ b/develop/reference_propagation.rst
@@ -1,3 +1,5 @@
+.. _manual_prop:
+
 Manual Query Propagation
 ========================
 

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -102,6 +102,30 @@ Citus is able to enforce a primary key or uniqueness constraint only when the co
 
 This restriction allows Citus to localize a uniqueness check to a single shard and let PostgreSQL on the worker node do the check efficiently.
 
+How do I create database roles, functions, extensions etc in a Citus cluster?
+-----------------------------------------------------------------------------
+
+Certain commands, when run on the coordinator node, do not get propagated to the workers:
+
+* ``CREATE ROLE/USER``
+* ``CREATE FUNCTION``
+* ``CREATE TYPE``
+* ``CREATE EXTENSION``
+* ``CREATE DATABASE``
+* ``ALTER … SET SCHEMA``
+* ``ALTER TABLE ALL IN TABLESPACE``
+
+It is still possible to use these commands by explicitly running them on all nodes. Citus provides a function to execute queries across all workers:
+
+.. code-block:: postgresql
+
+  SELECT run_command_on_workers($cmd$
+    /* the command to run */
+    CREATE FUNCTION ...
+  $cmd$);
+
+Learn more in :ref:`manual_prop`.
+
 What if a worker node's address changes?
 ----------------------------------------
 


### PR DESCRIPTION
Fixes #150 
Fixes #559 
Fixes #643 

This PR retains the propagation section in `extra/` to preserve any links we have shared with people to those sections. In the menu redesign we might consider adding a page redirect for that section.