### PR TITLE
Fix create_distributed_table's arg name.

### DIFF
--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -31,7 +31,7 @@ Arguments
 
 **distribution_column:** The column on which the table is to be distributed.
 
-**distribution_method:** (Optional) The method according to which the table is
+**distribution_type:** (Optional) The method according to which the table is
 to be distributed. Permissible values are append or hash, and defaults to 'hash'.
 
 **colocate_with:** (Optional) include current table in the co-location group of another table. By default tables are co-located when they are distributed by columns of the same type, have the same shard count, and have the same replication factor. Possible values for :code:`colocate_with` are :code:`default`, :code:`none` to start a new co-location group, or the name of another table to co-locate with that table.  (See :ref:`colocation_groups`.)


### PR DESCRIPTION
`create_distributed_table`'s first optional argument is named `distribution_type`, not `distribution_method`.

See https://github.com/citusdata/citus/blob/6c333d464fc74c544786bc5114a69ea76d47953f/src/backend/distributed/citus--6.1-4--6.1-5.sql#L9