### PR TITLE
New citus directly supports HLL aggregates

### DIFF
--- a/develop/reference_sql.rst
+++ b/develop/reference_sql.rst
@@ -55,20 +55,7 @@ For increased performance you can choose to make an approximate count instead. F
 HyperLogLog Column
 $$$$$$$$$$$$$$$$$$
 
-Certain users already store their data as HLL columns. In such cases, they can dynamically roll up those data by creating custom aggregates within Citus.
-
-As an example, if you want to run the hll_union aggregate function on your data stored as hll, you can define an aggregate function like below :
-
-.. code-block:: postgresql
-
-  CREATE AGGREGATE sum (hll)
-  (
-    sfunc = hll_union_trans,
-    stype = internal,
-    finalfunc = hll_pack
-  );
-
-You can then call sum(hll_column) to roll up those columns within the database. Please note that these custom aggregates need to be created both on the coordinator and the workers.
+Certain users already store their data as HLL columns. In such cases, they can dynamically roll up those data by calling hll_union_agg(hll_column).
 
 .. _limit_pushdown:
 

--- a/use_cases/realtime_analytics.rst
+++ b/use_cases/realtime_analytics.rst
@@ -174,7 +174,7 @@ The following function wraps the rollup query up for convenience.
   -- function to do the rollup
   CREATE OR REPLACE FUNCTION rollup_http_request() RETURNS void AS $$
   DECLARE
-    current_time     timestamptz := date_trunc('minute', now());
+    curr_rollup_time timestamptz := date_trunc('minute', now());
     last_rollup_time timestamptz := minute from latest_rollup;
   BEGIN
     INSERT INTO http_request_1min (
@@ -190,12 +190,12 @@ The following function wraps the rollup query up for convenience.
     FROM http_request
     -- roll up only data new since last_rollup_time
     WHERE date_trunc('minute', ingest_time) <@
-            tstzrange(last_rollup_time, current_time, '(]')
+            tstzrange(last_rollup_time, curr_rollup_time, '(]')
     GROUP BY 1, 2;
 
     -- update the value in latest_rollup so that next time we run the
-    -- rollup it will operate on data newer than current_time
-    UPDATE latest_rollup SET minute = current_time;
+    -- rollup it will operate on data newer than curr_rollup_time
+    UPDATE latest_rollup SET minute = curr_rollup_time;
   END;
   $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
Remove the custom aggs.

Also fixes a problem in the realtime use-case guide where a local variable `current_time` conflicted with the built-in variable. (I thought I fixed that already, but maybe it got messed up in a rebase…)

Fixes #695 