### PR TITLE
Unique index on non-distribution column

### DIFF
--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -232,6 +232,10 @@ Foreign keys must always be declared between either
 
 To set up a foreign key between colocated distributed tables, always include the distribution column in the key. This may involve making the key compound.
 
+.. note::
+
+  Primary keys and uniqueness constraints must include the distribution column. Adding them to a non-distribution column will generate an error (see :ref:`non_distribution_uniqueness`).
+
 This example shows how to create primary and foreign keys on distributed tables:
 
 .. code-block:: postgresql

--- a/reference/common_errors.rst
+++ b/reference/common_errors.rst
@@ -257,6 +257,8 @@ Resolution
 
 Add the table distribution column to both the select and insert statements, as well as the statement GROUP BY if applicable. For more info as well as a workaround, see :ref:`upsert_into_select`.
 
+.. _non_distribution_uniqueness:
+
 Cannot create uniqueness constraint
 -----------------------------------
 


### PR DESCRIPTION
Fixes #363 
Fixes #685 

Adds a section to our common error messages about it, with two workarounds. Also adds a note to the DDL section.