### PR TITLE
use JOIN keyword instead of obsolete implicit joins

### DIFF
--- a/use_cases/multi_tenant.rst
+++ b/use_cases/multi_tenant.rst
@@ -312,11 +312,11 @@ As a final demo of SQL support, we have a query which includes aggregates and wi
            PARTITION BY a.campaign_id
            ORDER BY a.campaign_id, count(*) desc
          ), count(*) as n_impressions, a.id
-    FROM ads as a,
-         impressions as i
-   WHERE a.company_id = 5
-     AND i.company_id = a.company_id
+    FROM ads as a
+    JOIN impressions as i
+      ON i.company_id = a.company_id
      AND i.ad_id      = a.id
+   WHERE a.company_id = 5
   GROUP BY a.campaign_id, a.id
   ORDER BY a.campaign_id, n_impressions desc;
 


### PR DESCRIPTION
Quoting [A history lesson on SQL joins (in Postgres)](https://www.citusdata.com/blog/2018/09/25/history-on-joins-in-postgres/) on the Citus blog:

> and if your intention is not to implement a CROSS JOIN then using a comma separated list of tables in your FROM clause looks deadly suspicious.
