### PR TITLE
Add warning about master_update_node blocking

### DIFF
--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -407,7 +407,7 @@ Example
 master_update_node
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-The master_update_node() function changes the hostname and port for a node registered in the Citus metadata table :ref:`pg_dist_node <pg_dist_node>`.
+The master_update_node() function changes the hostname and port for a node registered in the Citus metadata table :ref:`pg_dist_node <pg_dist_node>`. This function waits until all concurrent queries on the node are finished, so keep in mind that long-running queries will block it from executing.
 
 Arguments
 ************************


### PR DESCRIPTION
Fixes #595 

@ozgune is this what you wanted to warn people about?

To be honest I don't know exactly the sequence of how to use `master_update_node` -- if someone calls it after already changing a worker node's hostname then I don't see how existing queries could be running on the node and blocking the function. Or is this UDF meant to be called prior to actually changing the hostname?