### PR TITLE
A reassuring message about maintenance windows

### DIFF
--- a/cloud/performance.rst
+++ b/cloud/performance.rst
@@ -21,7 +21,7 @@ After you adjust the slider and/or buttons and accept the changes, Citus Cloud b
 
 .. image:: ../images/cloud-maintenance-window.png
 
-A maintenance window is just a way to indicate a time and day of the week that you prefer intensive changes to be performed. Only the action you specify will happen in the maintenance window, it doesn't set up a recurring event.
+A maintenance window specifies a preferred time for any maintenance tasks to be performed on your formation. When a window is set, changes to the formation (e.g. changing to a different worker size) will by default occur within this window, unless manually adjusted by Citus Cloud support. In addition, when a maintenance window is set, base backups on the node will start during the window.
 
 Citus Cloud will display a popup message in the console while scaling actions have begun or are scheduled. The message will disappear when the action completes.
 

--- a/cloud/performance.rst
+++ b/cloud/performance.rst
@@ -21,6 +21,8 @@ After you adjust the slider and/or buttons and accept the changes, Citus Cloud b
 
 .. image:: ../images/cloud-maintenance-window.png
 
+A maintenance window is just a way to indicate a time and day of the week that you prefer intensive changes to be performed. Only the action you specify will happen in the maintenance window, it doesn't set up a recurring event.
+
 Citus Cloud will display a popup message in the console while scaling actions have begun or are scheduled. The message will disappear when the action completes.
 
 For instance, when adding nodes:

--- a/cloud/upgrades.rst
+++ b/cloud/upgrades.rst
@@ -13,6 +13,8 @@ You may want to set a maintenance window prior to starting an upgrade. Part of t
 
 .. image:: ../images/cloud-maintenance-window.png
 
+A maintenance window is just a way to indicate a time and day of the week that you prefer intensive changes to be performed. Only the action you specify will happen in the maintenance window, it doesn't set up a recurring event.
+
 When you do start the upgrade, Citus Cloud creates new servers for the coordinator and worker nodes with the requested software versions, and replays the write-ahead log from the original nodes to transfer data. This can take a fair amount of time depending on the amount of data in existing nodes. During the transfer, the formation overview tab will contain a notice:
 
 .. image:: ../images/cloud-upgrading.png

--- a/cloud/upgrades.rst
+++ b/cloud/upgrades.rst
@@ -13,8 +13,6 @@ You may want to set a maintenance window prior to starting an upgrade. Part of t
 
 .. image:: ../images/cloud-maintenance-window.png
 
-A maintenance window is just a way to indicate a time and day of the week that you prefer intensive changes to be performed. Only the action you specify will happen in the maintenance window, it doesn't set up a recurring event.
-
 When you do start the upgrade, Citus Cloud creates new servers for the coordinator and worker nodes with the requested software versions, and replays the write-ahead log from the original nodes to transfer data. This can take a fair amount of time depending on the amount of data in existing nodes. During the transfer, the formation overview tab will contain a notice:
 
 .. image:: ../images/cloud-upgrading.png


### PR DESCRIPTION
Repeat the message in two places where someone might become worried
that the window is some kind of recurring event that uses resources,
rather than a period of time in which they can schedule their own
events manually.

Fixes #782 