### PR TITLE
Be more precise about foreign key support

### DIFF
--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -232,11 +232,13 @@ Adding/Removing Constraints
 
 Using Citus allows you to continue to enjoy the safety of a relational database, including database constraints (see the PostgreSQL `docs <https://www.postgresql.org/docs/current/static/ddl-constraints.html>`_). Due to the nature of distributed systems, Citus will not cross-reference uniqueness constraints or referential integrity between worker nodes.
 
-Foreign keys must always be declared between either
+Foreign keys may be created in these situations:
 
-* Two local (non-distributed) tables,
-* Two :ref:`colocated <colocation>` distributed tables, or
-* A distributed table and a :ref:`reference table <reference_tables>`
+* between two local (non-distributed) tables,
+* between two :ref:`colocated <colocation>` distributed tables, or
+* as a distributed table referencing a :ref:`reference table <reference_tables>`
+
+Reference tables are not supported as the *referencing* table of a foreign key constraint, i.e. keys from reference to reference and reference to distributed are not supported.
 
 To set up a foreign key between colocated distributed tables, always include the distribution column in the key. This may involve making the key compound.
 

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -235,7 +235,7 @@ Using Citus allows you to continue to enjoy the safety of a relational database,
 Foreign keys may be created in these situations:
 
 * between two local (non-distributed) tables,
-* between two :ref:`colocated <colocation>` distributed tables, or
+* between two :ref:`colocated <colocation>` distributed tables when the key includes the distribution column, or
 * as a distributed table referencing a :ref:`reference table <reference_tables>`
 
 Reference tables are not supported as the *referencing* table of a foreign key constraint, i.e. keys from reference to reference and reference to distributed are not supported.


### PR DESCRIPTION
Fixes #785 

You can verify with

```sql
begin;

create table dist ( id integer unique, ref_id integer );
create table ref ( id integer unique, dist_id integer );
create table ref2 ( id integer unique, ref_id integer );

select create_distributed_table('dist', 'id');
select create_reference_table('ref');
select create_reference_table('ref2');

commit;

begin;

alter table dist add constraint dist_ref_fk foreign key (ref_id) references ref (id);

-- bad things happen below -----------------
alter table ref add constraint ref_dist_fk foreign key (dist_id) references dist (id);
alter table ref2 add constraint ref_ref_fk foreign key (ref_id) references ref (id);

rollback;
```