### PR TITLE
Fix queries for (non-)qualified names

### DIFF
--- a/admin_guide/diagnostic_queries.rst
+++ b/admin_guide/diagnostic_queries.rst
@@ -232,7 +232,7 @@ This query will run across all worker nodes and identify any unused indexes for 
       WHERE NOT indisunique
       AND   idx_scan < 50
       AND   pg_relation_size(relid) > 5 * 8192
-      AND   schemaname || '.' || relname = '%s'
+      AND   (schemaname || '.' || relname)::regclass = '%s'::regclass
       ORDER BY
         pg_relation_size(i.indexrelid) / NULLIF(idx_scan, 0) DESC nulls first,
         pg_relation_size(i.indexrelid) DESC

--- a/develop/reference_propagation.rst
+++ b/develop/reference_propagation.rst
@@ -40,15 +40,17 @@ The :code:`run_command_on_shards` function applies a SQL command to each shard, 
   -- Get the estimated row count for a distributed table by summing the
   -- estimated counts of rows for each shard.
   SELECT sum(result::bigint) AS estimated_count
-  FROM run_command_on_shards(
-    'my_distributed_table',
-    $cmd$
-      SELECT reltuples
-        FROM pg_class c
-        JOIN pg_catalog.pg_namespace n on n.oid=c.relnamespace
-       WHERE n.nspname||'.'||relname = '%s';
-    $cmd$
-  );
+    FROM run_command_on_shards(
+      'my_distributed_table',
+      $cmd$
+        SELECT reltuples
+          FROM pg_class c
+          JOIN pg_catalog.pg_namespace n on n.oid=c.relnamespace
+         WHERE (n.nspname || '.' || relname)::regclass = '%s'::regclass
+           AND n.nspname NOT IN ('citus', 'pg_toast')
+      $cmd$
+    );
+
 
 Running on all Placements
 -------------------------

--- a/develop/reference_propagation.rst
+++ b/develop/reference_propagation.rst
@@ -47,7 +47,7 @@ The :code:`run_command_on_shards` function applies a SQL command to each shard, 
           FROM pg_class c
           JOIN pg_catalog.pg_namespace n on n.oid=c.relnamespace
          WHERE (n.nspname || '.' || relname)::regclass = '%s'::regclass
-           AND n.nspname NOT IN ('citus', 'pg_toast')
+           AND n.nspname NOT IN ('citus', 'pg_toast', 'pg_catalog')
       $cmd$
     );
 


### PR DESCRIPTION
Run_command_on_shards() removes 'public.' from its %s substitution,
but allows other schema names to remain. We convert to regclass to
resolve names to the proper relations before doing a comparison.

Fixes #725 