### PR TITLE
Fix docs for master_get_active_worker_nodes.

### DIFF
--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -604,8 +604,7 @@ master_get_active_worker_nodes
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
 The master_get_active_worker_nodes() function returns a list of active worker
-host names and port numbers. Currently, the function assumes that all the worker
-nodes in the pg_dist_node catalog table are active.
+host names and port numbers.
 
 Arguments
 ************************


### PR DESCRIPTION
This function doesn't assume all nodes in pg_dist_node are active.

e.g.

```
postgres=# select * from pg_dist_node;
 nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster
--------+---------+-----------+----------+----------+-------------+----------+----------+-------------
      3 |       3 | localhost |     5435 | default  | f           | f        | primary  | default
      1 |       1 | localhost |     5433 | default  | t           | t        | primary  | default
      2 |       2 | localhost |     5434 | default  | t           | t        | primary  | default
(3 rows)

Time: 0.717 ms
postgres=# select * from master_get_active_worker_nodes();
 node_name | node_port
-----------+-----------
 localhost |      5434
 localhost |      5433
(2 rows)

Time: 0.635 ms
```