### PR TITLE
Add all partmethod characters to docs

### DIFF
--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -23,9 +23,11 @@ The pg_dist_partition table stores metadata about which tables in the database a
 +----------------+----------------------+---------------------------------------------------------------------------+
 |  partmethod    |         char         | | The method used for partitioning / distribution. The values of this     |
 |                |                      | | column corresponding to different distribution methods are :-           |
-|                |                      | | append: 'a'                                                             |
-|                |                      | | hash: 'h'                                                               |
-|                |                      | | reference table: 'n'                                                    |
+|                |                      | | * append: 'a'                                                           |
+|                |                      | | * hash: 'h'                                                             |
+|                |                      | | * none: 'n'                                                             |
+|                |                      | | * range: 'r'                                                            |
+|                |                      | | * redistribute by hash: 'x'                                             |
 +----------------+----------------------+---------------------------------------------------------------------------+
 |   partkey      |         text         | | Detailed information about the distribution column including column     |
 |                |                      | | number, type and other relevant information.                            |


### PR DESCRIPTION
The source code (https://github.com/citusdata/citus/blob/master/src/include/distributed/pg_dist_partition.h) has the following constants:

```
/* valid values for partmethod include append, hash, and range */
#define DISTRIBUTE_BY_APPEND 'a'
#define DISTRIBUTE_BY_HASH 'h'
#define DISTRIBUTE_BY_RANGE 'r'
#define DISTRIBUTE_BY_NONE 'n'
#define REDISTRIBUTE_BY_HASH 'x'
```

The source comment is a bit unclear.  Are only `a`, `h` and `r` allowed or are all the characters allowed?