### PR TITLE
Add extra information around certificates

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -555,8 +555,8 @@ Once all files are in place on the nodes the following settings need to be confi
 
 .. code-block:: ini
 
-   # the following settings enable the postgres server to enable ssl and configure the server to present the certifacte
-   # to clients when connecting over tls/ssl
+   # the following settings enable the postgres server to enable ssl and configure the 
+   # server to present the certificate to clients when connecting over tls/ssl
    ssl = on
    ssl_key_file = '/path/to/server.key'
    ssl_cert_file = '/path/to/server.crt'

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -480,7 +480,7 @@ Connection Management
 
    Since Citus version 8.1.0 (released 2018-12-17) the traffic between the different nodes in the cluster is encrypted for NEW installations. This is done by using TLS with self-signed certificates. This means that this **does not protect against Man-In-The-Middle attacks.** This only protects against passive eavesdropping on the network.
 
-   For setting up self-signed TLS on installations that were originally created before Citus version 8.1.0 follow the steps in `official postgres documentation <https://www.postgresql.org/docs/current/ssl-tcp.html#SSL-CERTIFICATE-CREATION>`_ together with the citus specific settings described here. Setup should be done on coordinator and workers.
+   Clusters originally created with a Citus version before 8.1.0 do not have any network encryption enabled between nodes (even if upgraded later). To set up self-signed TLS on on this type of installation follow the steps in `official postgres documentation <https://www.postgresql.org/docs/current/ssl-tcp.html#SSL-CERTIFICATE-CREATION>`_ together with the citus specific settings described here, i.e. changing ``citus.node_conninfo`` to ``sslmode=require``. This setup should be done on coordinator and workers.
 
 When Citus nodes communicate with one another they consult a GUC for connection parameters and, in the Enterprise Edition of Citus, a table with connection credentials. This gives the database administrator flexibility to adjust parameters for security and efficiency.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -505,7 +505,7 @@ After changing this setting it is important to reload the postgres configuration
 
 .. warning:: 
 
-   Versions before 9.2.4 require a restart for existing connections to be closed.
+   Citus versions before 9.2.4 require a restart for existing connections to be closed.
 
    For these versions a reload of the configuration does not trigger connection ending and subsequent reconnecting. Instead the server should be restarted to enforce all connections to use the new settings.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -491,8 +491,7 @@ To set non-sensitive libpq connection parameters to be used for all node connect
   -- key=value pairs separated by spaces.
   -- For example, ssl options:
 
-  ALTER DATABASE foo
-  SET citus.node_conninfo =
+  ALTER SYSTEM SET citus.node_conninfo =
     'sslrootcert=/path/to/citus-ca.crt sslcrl=/path/to/citus-ca.crl sslmode=verify-full';
 
 There is a whitelist of parameters that the GUC accepts, see the :ref:`node_conninfo <node_conninfo>` reference for details. As of Citus 8.1, the default value for node_conninfo is ``sslmode=require``, which prevents unencrypted communication between nodes. If your cluster was originally created before Citus 8.1 the value will be ``sslmode=prefer``. After setting up self-signed certificates on all nodes it's recommended to change this setting to ``sslmode=require``.

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -562,9 +562,9 @@ Once all files are in place on the nodes the following settings need to be confi
    ssl_cert_file = '/path/to/server.crt'
 
    # this will tell citus to verify the certificate of the server it is connecting to 
-   citus.node_conninfo = 'sslmode=verify-ca sslrootcert=/path/to/ca.crt sslcrl=/path/to/ca.crl'
+   citus.node_conninfo = 'sslmode=verify-full sslrootcert=/path/to/ca.crt sslcrl=/path/to/ca.crl'
 
-Depending on the policy of the Certificate Authority used you might need or want to change ``sslmode=verify-ca`` in ``citus.node_conninfo`` to ``sslmode=verify-full``. For the difference between the two settings please consult `the official postgres documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_.
+Depending on the policy of the Certificate Authority used you might need or want to change ``sslmode=verify-full`` in ``citus.node_conninfo`` to ``sslmode=verify-ca``. For the difference between the two settings please consult `the official postgres documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_.
 
 Lastly, to prevent any user from connecting via an unencrypted connection changes need to be made to ``pg_hba.conf``. Many Postgres installations will have entries allowing ``host`` connections which both allow SSL/TLS connections as well as plain TCP connections. By changing all ``host`` entries with ``hostssl`` entries only encrypted connections will be allowed to authenticate to Postgres. For full documentation on these settings take a look at `the pg_hba.conf file <https://www.postgresql.org/docs/current/auth-pg-hba-conf.html>`_ documentation on the official Postgres documentation.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -536,11 +536,11 @@ Changing ``pg_dist_authinof`` does not force any existing connection to reconnec
 Setup Certificate Authority signed certificates
 -----------------------------------------------
 
-This section assumes you have a trusted Certificate Authority that can issue server certificates to you for all nodes in your cluster. It is recommended to work with the security department in your organisation to prevent key material be handled incorrectly. This guide only covers Citus specific configuration that needs to be applied, no best practices on PKI management.
+This section assumes you have a trusted Certificate Authority that can issue server certificates to you for all nodes in your cluster. It is recommended to work with the security department in your organization to prevent key material from being handled incorrectly. This guide covers only Citus specific configuration that needs to be applied, not best practices for PKI management.
 
 For all nodes in the cluster you need to get a valid certificate signed by the *same Certificate Authority*. The following **machine specific** files are assumed to be available on every machine:
  * ``/path/to/server.key``: Server Private Key
- * ``/path/to/server.crt``: Server Certifiacte or Certificate Chain for Server Key, signed by trusted Certifiacte Authority.
+ * ``/path/to/server.crt``: Server Certificate or Certificate Chain for Server Key, signed by trusted Certificate Authority.
 
 Next to these machine specific files you need these cluster or CA wide files available:
  * ``/path/to/ca.crt``: Certificate of the Certificate Authority
@@ -548,14 +548,15 @@ Next to these machine specific files you need these cluster or CA wide files ava
 
 .. note::
 
-   The Certificate Revocation List is likely to change over time. Work with your security department on a mechanism to get up to date versions of the revocation list on to all nodes in the cluster in a timely manner. A reload of every node in the cluster is required after the revocation list has been updated.
+   The Certificate Revocation List is likely to change over time. Work with your security department to set up a mechanism to update the revocation list on to all nodes in the cluster in a timely manner. A reload of every node in the cluster is required after the revocation list has been updated.
 
-Once all files are in place on the nodes the following settings need to be configured in the Postgres configuration file:
+Once all files are in place on the nodes, the following settings need to be configured in the Postgres configuration file:
 
 .. code-block:: ini
 
-   # the following settings enable the postgres server to enable ssl and configure the 
-   # server to present the certificate to clients when connecting over tls/ssl
+   # the following settings allow the postgres server to enable ssl, and
+   # configure the server to present the certificate to clients when
+   # connecting over tls/ssl
    ssl = on
    ssl_key_file = '/path/to/server.key'
    ssl_cert_file = '/path/to/server.crt'
@@ -563,15 +564,15 @@ Once all files are in place on the nodes the following settings need to be confi
    # this will tell citus to verify the certificate of the server it is connecting to 
    citus.node_conninfo = 'sslmode=verify-full sslrootcert=/path/to/ca.crt sslcrl=/path/to/ca.crl'
 
-After changing either restart the database or reload the configuration to apply these changes. A restart is required if a Citus version below 9.2.4 is used.
+After changing, either restart the database or reload the configuration to apply these changes. A restart is required if a Citus version below 9.2.4 is used.
 
 Depending on the policy of the Certificate Authority used you might need or want to change ``sslmode=verify-full`` in ``citus.node_conninfo`` to ``sslmode=verify-ca``. For the difference between the two settings please consult `the official postgres documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_.
 
-Lastly, to prevent any user from connecting via an unencrypted connection changes need to be made to ``pg_hba.conf``. Many Postgres installations will have entries allowing ``host`` connections which both allow SSL/TLS connections as well as plain TCP connections. By changing all ``host`` entries with ``hostssl`` entries only encrypted connections will be allowed to authenticate to Postgres. For full documentation on these settings take a look at `the pg_hba.conf file <https://www.postgresql.org/docs/current/auth-pg-hba-conf.html>`_ documentation on the official Postgres documentation.
+Lastly, to prevent any user from connecting via an un-encrypted connection, changes need to be made to ``pg_hba.conf``. Many Postgres installations will have entries allowing ``host`` connections which allow SSL/TLS connections as well as plain TCP connections. By replacing all ``host`` entries with ``hostssl`` entries, only encrypted connections will be allowed to authenticate to Postgres. For full documentation on these settings take a look at `the pg_hba.conf file <https://www.postgresql.org/docs/current/auth-pg-hba-conf.html>`_ documentation on the official Postgres documentation.
 
 .. note::
 
-   When a trusted Certificate Authority is not available one can create their own via a self-signed root certificate. This is non-trivial and the developer or operator should seek guidance from their security team when doing so.
+   When a trusted Certificate Authority is not available, one can create their own via a self-signed root certificate. This is non-trivial and the developer or operator should seek guidance from their security team when doing so.
 
 To verify the connections from the coordinator to the workers are encrypted you can run the following query. It will show the SSL/TLS version used to encrypt the connection that the coordinator uses to talk to the worker:
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -564,7 +564,7 @@ Once all files are in place on the nodes the following settings need to be confi
    # this will tell citus to verify the certificate of the server it is connecting to 
    citus.node_conninfo = 'sslmode=verify-full sslrootcert=/path/to/ca.crt sslcrl=/path/to/ca.crl'
 
-After changing either restart the database or reload the configuration.
+After changing either restart the database or reload the configuration to apply these changes. A restart is required if a Citus version below 9.2.4 is used.
 
 Depending on the policy of the Certificate Authority used you might need or want to change ``sslmode=verify-full`` in ``citus.node_conninfo`` to ``sslmode=verify-ca``. For the difference between the two settings please consult `the official postgres documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -480,7 +480,7 @@ Connection Management
 
    Since Citus version 8.1.0 (released 2018-12-17) the traffic between the different nodes in the cluster is encrypted for NEW installations. This is done by using TLS with self-signed certificates. This means that this **does not protect against Man-In-The-Middle attacks.** This only protects against passive eavesdropping on the network.
 
-   For setting up TLS on existing installations follow the steps in `official postgres documentation <https://www.postgresql.org/docs/current/ssl-tcp.html#SSL-CERTIFICATE-CREATION>`_ together with the citus specific settings described here. Setup should be done on coordinator and workers.
+   For setting up self-signed TLS on installations that were originally created before Citus version 8.1.0 follow the steps in `official postgres documentation <https://www.postgresql.org/docs/current/ssl-tcp.html#SSL-CERTIFICATE-CREATION>`_ together with the citus specific settings described here. Setup should be done on coordinator and workers.
 
 When Citus nodes communicate with one another they consult a GUC for connection parameters and, in the Enterprise Edition of Citus, a table with connection credentials. This gives the database administrator flexibility to adjust parameters for security and efficiency.
 
@@ -705,4 +705,3 @@ In the new db on every worker, manually run:
   CREATE EXTENSION citus;
 
 Now the new database will be operating as another Citus cluster.
-

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -532,9 +532,7 @@ After this INSERT, any query needing to connect to node 123 as the user jdoe wil
 
 This changes the user from using a password to use a certificate and keyfile while connecting to node 123 instead. Make sure the user certificate is signed by a certificate that is trusted by the worker you are connecting to and authentication settings on the worker allow for certificate based authentication. Full documentation on how to use client certificates can be found in `the postgres libpq documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-CLIENTCERT>`_.
 
-.. note::
-
-   Same reload and restart policy applies to ``pg_dist_authinfo`` as described above for ``citus.node_conninfo``.
+Changing ``pg_dist_authinof`` does not force any existing connection to reconnect.
 
 .. _worker_security:
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -539,12 +539,14 @@ Setup Certificate Authority signed certificates
 This section assumes you have a trusted Certificate Authority that can issue server certificates to you for all nodes in your cluster. It is recommended to work with the security department in your organization to prevent key material from being handled incorrectly. This guide covers only Citus specific configuration that needs to be applied, not best practices for PKI management.
 
 For all nodes in the cluster you need to get a valid certificate signed by the *same Certificate Authority*. The following **machine specific** files are assumed to be available on every machine:
- * ``/path/to/server.key``: Server Private Key
- * ``/path/to/server.crt``: Server Certificate or Certificate Chain for Server Key, signed by trusted Certificate Authority.
+
+* ``/path/to/server.key``: Server Private Key
+* ``/path/to/server.crt``: Server Certificate or Certificate Chain for Server Key, signed by trusted Certificate Authority.
 
 Next to these machine specific files you need these cluster or CA wide files available:
- * ``/path/to/ca.crt``: Certificate of the Certificate Authority
- * ``/path/to/ca.crl``: Certificate Revocation List of the Certificate Authority
+
+* ``/path/to/ca.crt``: Certificate of the Certificate Authority
+* ``/path/to/ca.crl``: Certificate Revocation List of the Certificate Authority
 
 .. note::
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -499,7 +499,7 @@ There is a whitelist of parameters that the GUC accepts, see the :ref:`node_conn
 
 After changing this setting it is important to reload the postgres configuration. Even though the changed setting might be visible in all sessions, the setting is only consulted by Citus when new connections are established. When a reload signal is received citus marks all existing connections to be closed which causes a reconnect after running transactions have been completed.
 
-... code-block:: postgresql
+.. code-block:: postgresql
 
   SELECT pg_reload_conf();
 
@@ -553,7 +553,7 @@ Next to these machine specific files you need these cluster or CA wide files ava
 
 Once all files are in place on the nodes the following settings need to be configured in the Postgres configuration file:
 
-.. code:: ini
+.. code-block:: ini
 
    # the following settings enable the postgres server to enable ssl and configure the server to present the certifacte
    # to clients when connecting over tls/ssl

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -495,7 +495,7 @@ To set non-sensitive libpq connection parameters to be used for all node connect
   SET citus.node_conninfo =
     'sslrootcert=/path/to/citus-ca.crt sslcrl=/path/to/citus-ca.crl sslmode=verify-full';
 
-There is a whitelist of parameters that the GUC accepts, see the :ref:`node_conninfo <node_conninfo>` reference for details. As of Citus 8.1, the default value for node_conninfo is ``sslmode=require``, which prevents unencrypted communication between nodes.
+There is a whitelist of parameters that the GUC accepts, see the :ref:`node_conninfo <node_conninfo>` reference for details. As of Citus 8.1, the default value for node_conninfo is ``sslmode=require``, which prevents unencrypted communication between nodes. If your cluster was originally created before Citus 8.1 the value will be ``sslmode=prefer``. After setting up self-signed certificates on all nodes it's recommended to change this setting to ``sslmode=require``.
 
 After changing this setting it is important to reload the postgres configuration. Even though the changed setting might be visible in all sessions, the setting is only consulted by Citus when new connections are established. When a reload signal is received citus marks all existing connections to be closed which causes a reconnect after running transactions have been completed.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -580,6 +580,8 @@ To verify the connections from the coordinator to the workers are encrypted you 
   SELECT run_command_on_workers($$
     SELECT version FROM pg_stat_ssl WHERE pid = pg_backend_pid()
   $$);
+
+::
   
   ┌────────────────────────────┐
   │   run_command_on_workers   │

--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -116,6 +116,16 @@ Citus honors only a whitelisted subset of the options, namely:
 
 *(† = subject to the runtime presence of optional PostgreSQL features)*
 
+Setting only takes effect on newly opened connections. To force all connections to use the new settings make sure to reload the postgres configuration:
+
+.. code-block:: postgresql
+
+   SELECT pg_reload_conf();
+
+.. warning::
+
+   Citus versions prior to 9.2.4 require a full database restart to force all connections to use the new setting.
+
 .. _override_table_visibility:
 
 citus.override_table_visibility (boolean)

--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -116,7 +116,7 @@ Citus honors only a whitelisted subset of the options, namely:
 
 *(† = subject to the runtime presence of optional PostgreSQL features)*
 
-Setting only takes effect on newly opened connections. To force all connections to use the new settings make sure to reload the postgres configuration:
+The ``node_conninfo`` setting takes effect only on newly opened connections. To force all connections to use the new settings, make sure to reload the postgres configuration:
 
 .. code-block:: postgresql
 


### PR DESCRIPTION
Citus has some defaults around newly created clusters (since 8.1) that do setup self signed certificates. It needs to be explicitly stated that self signed certificates only prevent to passive Man-In-The-Middle attacks.

If users upgrade from a Citus cluster that predates the auto self signed certificate setup we have a link to the official postgres documentation on how to setup certificates for postgres, these steps can be followed on the coordinator and the workers to achieve the same. By combining the steps with an actual Certificate Authority the reader could also setup a fully verified TLS connection.

Since 9.2.4 (to be released instead of our wrongfully packaged 9.2.3) it is possible to make sure Citus closes all connections any backend has open after a configuration change by reloading the postgres configuration via `pg_reload_conf()`. This is reflected in the documentation with a warning indicating a database restart is required in versions prior to 9.2.4.

Fixes #909