### PR TITLE
Add a Makefile for easy command running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+docs:
+	sphinx-build -b html -W -n . _build
+
+clean:
+	rm -rf _build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+.PHONY: docs watch clean
+
 docs:
 	sphinx-build -b html -W -n . _build
+
+watch:
+	sphinx-autobuild -b html -W -n . _build
 
 clean:
 	rm -rf _build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To generate HTML version:
 4. Generate HTML
     ```bash
     cd citus_docs
-    sphinx-build -b html -a -n . _build
+    make
 
     # open _build/index.html in your browser
     ```


### PR DESCRIPTION
This also changes the command that was shown in the README in two ways:
1. `-a` is removed. This makes the build quicker by doing incremental builds.
2. `-W` is added. This changes warnings into errors, so they don't
   accidentily slip in.