### PR TITLE
No longer a need to manually propagate grant select

### DIFF
--- a/cloud/security.rst
+++ b/cloud/security.rst
@@ -130,11 +130,6 @@ Citus propagates single-table GRANT statements through the entire cluster, makin
   -- applies to the coordinator node
   GRANT SELECT ON ALL TABLES IN SCHEMA public TO reports;
 
-  -- make it apply to workers as well
-  SELECT run_command_on_workers(
-    'GRANT SELECT ON ALL TABLES IN SCHEMA public TO reports;'
-  );
-
 .. _grant_usage:
 
 Granting Access to Other Schemas


### PR DESCRIPTION
Verified with Citus 9.2 on Hyperscale that "grant select on all tables in schema" works all by itself and does not require run_command_on_workers.