### PR TITLE
Update tutorial_multi_tenant.rst

### DIFF
--- a/get_started/tutorial_multi_tenant.rst
+++ b/get_started/tutorial_multi_tenant.rst
@@ -216,6 +216,7 @@ We can also run a join query across multiple tables to see information about run
            sum(impressions_count) as total_impressions, sum(clicks_count) as total_clicks
     FROM ads, campaigns
     WHERE ads.company_id = campaigns.company_id
+    AND ads.campaign_id = campaigns.id
     AND campaigns.company_id = 5
     AND campaigns.state = 'running'
     GROUP BY campaigns.id, campaigns.name, campaigns.monthly_budget


### PR DESCRIPTION
The last query lacks this where clause `AND ads.campaign_id = campaigns.id`

```
SELECT campaigns.id, campaigns.name, campaigns.monthly_budget,
       sum(impressions_count) as total_impressions, sum(clicks_count) as total_clicks
FROM ads, campaigns
WHERE ads.company_id = campaigns.company_id
AND campaigns.company_id = 5
AND campaigns.state = 'running'
GROUP BY campaigns.id, campaigns.name, campaigns.monthly_budget
ORDER BY total_impressions, total_clicks;
```



