### PR TITLE
Update realtime_analytics.rst

### DIFF
--- a/use_cases/realtime_analytics.rst
+++ b/use_cases/realtime_analytics.rst
@@ -175,7 +175,7 @@ The following function wraps the rollup query up for convenience.
   -- function to do the rollup
   CREATE OR REPLACE FUNCTION rollup_http_request() RETURNS void AS $$
   DECLARE
-    curr_rollup_time timestamptz := date_trunc('minute', now());
+    curr_rollup_time timestamptz := date_trunc('minute', now() - interval '1 minute');
     last_rollup_time timestamptz := minute from latest_rollup;
   BEGIN
     INSERT INTO http_request_1min (


### PR DESCRIPTION
Because the current minute (`date_trunc('minute', now())`) has not passed yet, records that are inserted in the current minute but after the function execution will never be aggregated into `http_request_1min` table. We need to assign one minute before the current minute (`date_trunc('minute', now() - interval '1 minute')`) to `curr_rollup_time`.