### PR TITLE
Docs updates (mainly outputs & table descriptions)

### DIFF
--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -73,15 +73,15 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
 The ``citus.node_connection_timeout`` GUC sets the maximum duration (in milliseconds) to wait for connection establishment. Citus raises an error if the timeout elapses before at least one worker connection is established. This GUC affects connections from the coordinator to workers, and workers to each other.
 
-* Default: five seconds
+* Default: thirty seconds
 * Minimum: ten milliseconds
 * Maximum: one hour
 
 .. code-block:: postgresql
 
-  -- set to 30 seconds
+  -- set to 60 seconds
   ALTER DATABASE foo
-  SET citus.node_connection_timeout = 30000;
+  SET citus.node_connection_timeout = 60000;
 
 .. _node_conninfo:
 

--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -165,7 +165,7 @@ Sets the commit protocol to use when performing COPY on a hash distributed table
 
 * **2pc:** (default) The transactions in which COPY is performed on the shard placements are first prepared using PostgreSQL's `two-phase commit <http://www.postgresql.org/docs/current/static/sql-prepare-transaction.html>`_ and then committed. Failed commits can be manually recovered or aborted using COMMIT PREPARED or ROLLBACK PREPARED, respectively. When using 2pc, `max_prepared_transactions <http://www.postgresql.org/docs/current/static/runtime-config-resource.html>`_ should be increased on all the workers, typically to the same value as max_connections.
 
-* **1pc:** The transactions in which COPY is performed on the shard placements is committed in a single round. Data may be lost if a commit fails after COPY succeeds on all placements (rare).
+* **1pc:** The transactions in which COPY is performed on the shard placements are committed in a single round. Data may be lost if a commit fails after COPY succeeds on all placements (rare).
 
 .. _replication_factor:
 
@@ -212,7 +212,7 @@ there are large reference tables.
 
 You can defer reference table replication by setting the
 ``citus.replicate_reference_tables_on_activate`` GUC to 'off'. Reference table
-replication will then happen we create new shards on the node. For instance,
+replication will then happen when we create new shards on the node. For instance,
 when calling :ref:`create_distributed_table`, :ref:`create_reference_table`,
 :ref:`upgrade_to_reference_table`, or when the shard rebalancer moves shards to
 the new node.
@@ -443,7 +443,7 @@ enabled, the executor might choose to use fewer connections to optimize overall
 query execution throughput. Internally, setting this true will end up using one
 connection per task.
 
-Once place where this is useful is in a transaction whose first query is
+One place where this is useful is in a transaction whose first query is
 lightweight and requires few connections, while a subsequent query would
 benefit from more connections. Citus decides how many connections to use in a
 transaction based on the first statement, which can throttle other queries

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -334,25 +334,28 @@ Co-location group table
 
 The pg_dist_colocation table contains information about which tables' shards should be placed together, or :ref:`co-located <colocation>`. When two tables are in the same co-location group, Citus ensures shards with the same partition values will be placed on the same worker nodes. This enables join optimizations, certain distributed rollups, and foreign key support. Shard co-location is inferred when the shard counts, replication factors, and partition column types all match between two tables; however, a custom co-location group may be specified when creating a distributed table, if so desired.
 
-+------------------------+----------------------+---------------------------------------------------------------------------+
-|      Name              |         Type         |       Description                                                         |
-+========================+======================+===========================================================================+
-| colocationid           |         int          | | Unique identifier for the co-location group this row corresponds to.    |
-+------------------------+----------------------+---------------------------------------------------------------------------+
-| shardcount             |         int          | | Shard count for all tables in this co-location group                    |
-+------------------------+----------------------+---------------------------------------------------------------------------+
-| replicationfactor      |         int          | | Replication factor for all tables in this co-location group.            |
-+------------------------+----------------------+---------------------------------------------------------------------------+
-| distributioncolumntype |         oid          | | The type of the distribution column for all tables in this              |
-|                        |                      | | co-location group.                                                      |
-+------------------------+----------------------+---------------------------------------------------------------------------+
++-----------------------------+----------------------+---------------------------------------------------------------------------+
+|      Name                   |         Type         |       Description                                                         |
++=============================+======================+===========================================================================+
+| colocationid                |         int          | | Unique identifier for the co-location group this row corresponds to.    |
++-----------------------------+----------------------+---------------------------------------------------------------------------+
+| shardcount                  |         int          | | Shard count for all tables in this co-location group                    |
++-----------------------------+----------------------+---------------------------------------------------------------------------+
+| replicationfactor           |         int          | | Replication factor for all tables in this co-location group.            |
++-----------------------------+----------------------+---------------------------------------------------------------------------+
+| distributioncolumntype      |         oid          | | The type of the distribution column for all tables in this              |
+|                             |                      | | co-location group.                                                      |
++-----------------------------+----------------------+---------------------------------------------------------------------------+
+| distributioncolumncollation |         oid          | | The collation of the distribution column for all tables in this         |
+|                             |                      | | co-location group.                                                      |
++-----------------------------+----------------------+---------------------------------------------------------------------------+
 
 ::
 
     SELECT * from pg_dist_colocation;
-      colocationid | shardcount | replicationfactor | distributioncolumntype 
-     --------------+------------+-------------------+------------------------
-                 2 |         32 |                 2 |                     20
+      colocationid | shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation
+     --------------+------------+-------------------+------------------------+-----------------------------
+                 2 |         32 |                 2 |                     20 |                           0
       (1 row)
 
 .. _pg_dist_rebalance_strategy:

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -121,6 +121,8 @@ The pg_dist_placement table tracks the location of shard replicas on worker node
 +----------------+----------------------+---------------------------------------------------------------------------+
 |      Name      |         Type         |       Description                                                         |
 +================+======================+===========================================================================+
+| placementid    |       bigint         | | Unique auto-generated identifier for each individual placement.         |
++----------------+----------------------+---------------------------------------------------------------------------+
 | shardid        |       bigint         | | Shard identifier associated with this placement. This value references  |
 |                |                      | | the shardid column in the pg_dist_shard catalog table.                  |
 +----------------+----------------------+---------------------------------------------------------------------------+ 
@@ -131,8 +133,6 @@ The pg_dist_placement table tracks the location of shard replicas on worker node
 |                |                      | | worker node in bytes.                                                   |
 |                |                      | | For hash distributed tables, zero.                                      |
 +----------------+----------------------+---------------------------------------------------------------------------+
-| placementid    |       bigint         | | Unique auto-generated identifier for each individual placement.         |
-+----------------+----------------------+---------------------------------------------------------------------------+
 | groupid        |         int          | | Identifier used to denote a group of one primary server and zero or more|
 |                |                      | | secondary servers, when the streaming replication model is used.        |
 +----------------+----------------------+---------------------------------------------------------------------------+
@@ -140,15 +140,15 @@ The pg_dist_placement table tracks the location of shard replicas on worker node
 ::
 
   SELECT * from pg_dist_placement;
-    shardid | shardstate | shardlength | placementid | groupid
-   ---------+------------+-------------+-------------+---------
-     102008 |          1 |           0 |           1 |       1
-     102008 |          1 |           0 |           2 |       2
-     102009 |          1 |           0 |           3 |       2
-     102009 |          1 |           0 |           4 |       3
-     102010 |          1 |           0 |           5 |       3
-     102010 |          1 |           0 |           6 |       4
-     102011 |          1 |           0 |           7 |       4
+    placementid | shardid | shardstate | shardlength | groupid
+   -------------+---------+------------+-------------+---------
+              1 |  102008 |          1 |           0 |       1
+              2 |  102008 |          1 |           0 |       2
+              3 |  102009 |          1 |           0 |       2
+              4 |  102009 |          1 |           0 |       3
+              5 |  102010 |          1 |           0 |       3
+              6 |  102010 |          1 |           0 |       4
+              7 |  102011 |          1 |           0 |       4
 
 .. note::
 

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -346,8 +346,8 @@ The pg_dist_colocation table contains information about which tables' shards sho
 | distributioncolumntype      |         oid          | | The type of the distribution column for all tables in this              |
 |                             |                      | | co-location group.                                                      |
 +-----------------------------+----------------------+---------------------------------------------------------------------------+
-| distributioncolumncollation |         oid          | | The collation of the distribution column for all tables in this         |
-|                             |                      | | co-location group.                                                      |
+| distributioncolumncollation |         oid          | | The collation of the distribution column for all tables in              |
+|                             |                      | | this co-location group.                                                 |
 +-----------------------------+----------------------+---------------------------------------------------------------------------+
 
 ::

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -228,6 +228,8 @@ The pg_dist_node table contains information about the worker nodes in the cluste
 +------------------+----------------------+---------------------------------------------------------------------------+
 | nodecluster      |        text          | | The name of the cluster containing this node                            |
 +------------------+----------------------+---------------------------------------------------------------------------+
+| metadatasynced   |        boolean       | | Reserved for internal use.                                              |
++------------------+----------------------+---------------------------------------------------------------------------+
 | shouldhaveshards |        boolean       | | If false, shards will be moved off node (drained) when rebalancing,     |
 |                  |                      | | nor will shards from new distributed tables be placed on the node,      |
 |                  |                      | | unless they are colocated with shards already there                     |
@@ -236,11 +238,11 @@ The pg_dist_node table contains information about the worker nodes in the cluste
 ::
 
     SELECT * from pg_dist_node;
-     nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | shouldhaveshards
-    --------+---------+-----------+----------+----------+-------------+----------+----------+-------------+------------------
-          1 |       1 | localhost |    12345 | default  | f           | t        | primary  | default     | t
-          2 |       2 | localhost |    12346 | default  | f           | t        | primary  | default     | t
-          3 |       3 | localhost |    12347 | default  | f           | t        | primary  | default     | t
+     nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole | nodecluster | metadatasynced | shouldhaveshards
+    --------+---------+-----------+----------+----------+-------------+----------+----------+-------------+----------------+------------------
+          1 |       1 | localhost |    12345 | default  | f           | t        | primary  | default     | f              | t
+          2 |       2 | localhost |    12346 | default  | f           | t        | primary  | default     | f              | t
+          3 |       3 | localhost |    12347 | default  | f           | t        | primary  | default     | f              | t
     (3 rows)
 
 .. _pg_dist_object:

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -578,7 +578,7 @@ Citus provides special views to watch queries and locks throughout the cluster, 
 * **citus_worker_stat_activity**: shows queries on workers, including fragment queries against individual shards.
 * **citus_lock_waits**: Blocked queries throughout the cluster.
 
-The first two views include all columns of `pg_stat_activity <https://www.postgresql.org/docs/current/static/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW>`_ plus the host host/port of the worker that initiated the query and the host/port of the coordinator node of the cluster.
+The first two views include all columns of `pg_stat_activity <https://www.postgresql.org/docs/current/static/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW>`_ plus the host/port of the worker that initiated the query and the host/port of the coordinator node of the cluster.
 
 For example, consider counting the rows in a distributed table:
 

--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -212,7 +212,7 @@ Failing this, Citus will raise an error. For instance, attempting to colocate ta
 
 ::
 
-  ERROR:  XX000: cannot colocate tables apples and oranges
+  ERROR:  cannot colocate tables apples and oranges
   DETAIL:  Distribution column types don't match for apples and oranges.
 
 Return Value

--- a/develop/app_type.rst
+++ b/develop/app_type.rst
@@ -19,7 +19,7 @@ At a Glance
 +----------------------------------------------------------+-------------------------------------------------------+
 | OLTP workloads for serving web clients                   | High ingest volume of mostly immutable data           |
 +----------------------------------------------------------+-------------------------------------------------------+
-| OLAP workloads that serve per-tenant analytical queries  | Often centering around big table of events            |
+| OLAP workloads that serve per-tenant analytical queries  | Often centering around a big table of events          |
 +----------------------------------------------------------+-------------------------------------------------------+
 
 Examples and Characteristics

--- a/develop/append.rst
+++ b/develop/append.rst
@@ -229,7 +229,7 @@ COPY creates new shards every time it is used, which allows many files to be ing
 
     -- Prepare a staging table
     CREATE TABLE stage_1 (LIKE events);
-    \COPY stage_1 FROM 'path-to-csv-file WITH CSV
+    \COPY stage_1 FROM 'path-to-csv-file' WITH CSV
 
     -- In a separate transaction, append the staging table
     SELECT master_append_table_to_shard(select_events_shard(), 'stage_1', 'coordinator-host', 5432);

--- a/develop/migration_mt_asp.rst
+++ b/develop/migration_mt_asp.rst
@@ -48,7 +48,7 @@ in the ``tenants`` table. You could also look up tenants by subdomain
 (or any other scheme you want).
 
 Notice how the ``tenant_id`` is also stored in the ``questions``
-table?  This will make it possible to :ref:`colocate <colocation>` the
+table. This will make it possible to :ref:`colocate <colocation>` the
 data. With the tables created, use ``create_distributed table`` to tell
 Citus to shard on the tenant ID:
 

--- a/develop/migration_mt_django.rst
+++ b/develop/migration_mt_django.rst
@@ -57,7 +57,7 @@ The tricky thing with this pattern is that in order to find all tasks for an acc
 1. Introducing the tenant column to models belonging to an account
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**1.1 Introducting the column to models belonging to an account**
+**1.1 Introducing the column to models belonging to an account**
 
 In order to scale out a multi-tenant model, it’s essential for queries to quickly
 locate all records that belong to an account. Consider an ORM call such as:
@@ -265,7 +265,7 @@ Then generate the migration with:
 
   python manage.py makemigrations
 
-Some ``UNIQUE`` constraints are created by the ORM and you will need to explicitily drop them.
+Some ``UNIQUE`` constraints are created by the ORM and you will need to explicitly drop them.
 This is the case for ``OneToOneField`` and ``ManyToMany`` fields.
 
 For these cases you will need to:
@@ -329,7 +329,7 @@ In requirements.txt for your Django application, add
 
 Run ``pip install -r requirements.txt``.
 
-In settings.py, change the database engine to the customized engine provied by django-multitenant:
+In settings.py, change the database engine to the customized engine provided by django-multitenant:
 
 .. code-block:: python
 
@@ -493,7 +493,7 @@ At this point the Django application models are ready to work with a Citus backe
 Updating the Django Application to scope queries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The django-multitenant library discussed in the previous section is not only useful for migrations, but for simplifying application queries. The library allows application code to easily scope queries to a single tenant. It automatically adds the correct SQL filters to all statements, including fetching objects through relations.
+The django-multitenant library discussed in the previous section is not only useful for migrations, but also for simplifying application queries. The library allows application code to easily scope queries to a single tenant. It automatically adds the correct SQL filters to all statements, including fetching objects through relations.
 
 For instance, in a view simply ``set_current_tenant`` and all the queries or joins afterward will include a filter to scope results to a single tenant.
 
@@ -506,7 +506,7 @@ For instance, in a view simply ``set_current_tenant`` and all the queries or joi
   # now this count query applies only to Project for that account
   Project.objects.count()
 
-  # Find tasks for very import projects in the current account
+  # Find tasks for very important projects in the current account
   Task.objects.filter(project__name='Very important project')
 
 In the context of an application view, the current tenant object can be stored as a SESSION variable when a user logs in, and view actions can :code:`set_current_tenant` to this value. See the README in django-multitenant for more examples.

--- a/develop/migration_mt_ror.rst
+++ b/develop/migration_mt_ror.rst
@@ -236,7 +236,7 @@ Updating the Test Suite
 If the test suite for your Rails application uses the
 ``database_cleaner`` gem to reset the test database between
 runs, be sure to use the "truncation" strategy rather than
-"transaction." We have seen occassional failures during transaction
+"transaction." We have seen occasional failures during transaction
 rollbacks in the tests. The database_cleaner `documentation
 <https://www.rubydoc.info/gems/database_cleaner#How_to_use>`_ has
 instructions for changing the cleaning strategy.

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -99,6 +99,9 @@ The :code:`create_distributed_table` function described earlier works on both em
   CREATE TABLE series AS SELECT i FROM generate_series(1,1000000) i;
   SELECT create_distributed_table('series', 'i');
   NOTICE:  Copying data from local table...
+  NOTICE:  copying the data has completed
+  DETAIL:  The local data in the table is no longer visible, but is still on disk.
+  HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.series$$)
    create_distributed_table
    --------------------------
 

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -227,8 +227,7 @@ Attempting to do so causes an error:
   ALTER COLUMN store_id TYPE text;
 
   /*
-  ERROR:  XX000: cannot execute ALTER TABLE command involving partition column
-  LOCATION:  ErrorIfUnsupportedAlterTableStmt, multi_utility.c:2150
+  ERROR:  cannot execute ALTER TABLE command involving partition column
   */
 
 However there's a workaround of re-creating the distributed table. See :ref:`change_dist_col`.

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -223,7 +223,7 @@ Attempting to do so causes an error:
 
 .. code-block:: postgres
 
-  -- assumining store_id is the distribution column
+  -- assuming store_id is the distribution column
   -- for products, and that it has type integer
 
   ALTER TABLE products

--- a/develop/reference_dml.rst
+++ b/develop/reference_dml.rst
@@ -49,7 +49,7 @@ Citus also supports ``INSERT … SELECT`` statements -- which insert rows based 
 
 In Citus there are three ways that inserting from a select statement can happen. The first is if the source tables and destination table are :ref:`colocated <colocation>`, and the select/insert statements both include the distribution column. In this case Citus can push the ``INSERT … SELECT`` statement down for parallel execution on all nodes.
 
-The second way of executing an ``INSERT … SELECT`` statement is by repartioning the results of the result set into chunks, and sending those chunks among workers to matching destination table shards. Each worker node can insert the values into local destination shards.
+The second way of executing an ``INSERT … SELECT`` statement is by repartitioning the results of the result set into chunks, and sending those chunks among workers to matching destination table shards. Each worker node can insert the values into local destination shards.
 
 The repartitioning optimization can happen when the SELECT query doesn't require a merge step on the coordinator. It doesn't work with the following SQL features, which require a merge step:
 
@@ -57,7 +57,7 @@ The repartitioning optimization can happen when the SELECT query doesn't require
 * LIMIT
 * OFFSET
 * GROUP BY when distribution column is not part of the group key
-* Window functions when partition by a non-distribution column in the source table(s)
+* Window functions when partitioning by a non-distribution column in the source table(s)
 * Joins between non-colocated tables (i.e. repartition joins)
 
 When the source and destination tables are not colocated, and the repartition optimization cannot be applied, then Citus uses the third way of executing ``INSERT … SELECT``. It selects the results from worker nodes, and pulls the data up to the coordinator node. The coordinator redirects rows back down to the appropriate shard. Because all the data must pass through a single node, this method is not as efficient.

--- a/develop/reference_processing.rst
+++ b/develop/reference_processing.rst
@@ -57,7 +57,7 @@ For example, having subqueries in a WHERE clause sometimes cannot execute inline
   )
   GROUP BY page_id;
 
-The executor would like to run a fragment of this query against each shard by page_id, counting distinct host_ips, and combining the results on the coordinator. However the LIMIT in the subquery means the subquery cannot be executed as part of the fragment. By recursively planning the query Citus can run the subquery separately, push the results to all workers, run the main fragment query, and pull the results back to the coordinator. The "push-pull" design supports a subqueries like the one above.
+The executor would like to run a fragment of this query against each shard by page_id, counting distinct host_ips, and combining the results on the coordinator. However the LIMIT in the subquery means the subquery cannot be executed as part of the fragment. By recursively planning the query Citus can run the subquery separately, push the results to all workers, run the main fragment query, and pull the results back to the coordinator. The "push-pull" design supports subqueries like the one above.
 
 Let's see this in action by reviewing the `EXPLAIN <https://www.postgresql.org/docs/current/static/sql-explain.html>`_ output for this query. It's fairly involved:
 

--- a/develop/reference_propagation.rst
+++ b/develop/reference_propagation.rst
@@ -89,7 +89,7 @@ A useful companion to :code:`run_command_on_placements` is :code:`run_command_on
   SELECT create_distributed_table('little_vals', 'key');
   SELECT create_distributed_table('big_vals',    'key');
 
-  -- We want to synchronise them so that every time little_vals
+  -- We want to synchronize them so that every time little_vals
   -- are created, big_vals appear with double the value
   --
   -- First we make a trigger function on each worker, which will

--- a/develop/reference_workarounds.rst
+++ b/develop/reference_workarounds.rst
@@ -180,7 +180,7 @@ In our :ref:`real-time analytics tutorial <real_time_analytics_tutorial>` we
 created a table called :code:`github_events`, distributed by the column
 :code:`user_id`. Let's query it and find the earliest events for a preselected
 set of repos, grouped by combinations of event type and event publicity. A
-convenient way to do this is with gouping sets. However, as mentioned, this
+convenient way to do this is with grouping sets. However, as mentioned, this
 feature is not yet supported in distributed queries:
 
 .. code-block:: sql

--- a/develop/reference_workarounds.rst
+++ b/develop/reference_workarounds.rst
@@ -198,7 +198,7 @@ feature is not yet supported in distributed queries:
 
 ::
 
-  ERROR:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
+  ERROR:  could not run distributed query with GROUPING
   HINT:  Consider using an equality filter on the distributed table's partition column.
 
 There is a trick, though. We can pull the relevant information to the coordinator as a temporary table:

--- a/develop/reference_workarounds.rst
+++ b/develop/reference_workarounds.rst
@@ -44,8 +44,6 @@ Attempting to execute a JOIN between a local table "local" and a distributed tab
   /*
   ERROR:  relation local is not distributed
   STATEMENT:  SELECT * FROM local JOIN dist USING (id);
-  ERROR:  XX000: relation local is not distributed
-  LOCATION:  DistributedTableCacheEntry, metadata_cache.c:711
   */
 
 Although you can't join such tables directly, by wrapping the local table in a subquery or CTE you can make Citus' recursive query planner copy the local table data to worker nodes. By colocating the data this allows the query to proceed.

--- a/reference/common_errors.rst
+++ b/reference/common_errors.rst
@@ -114,9 +114,8 @@ When all available worker connection slots are in use, further connections will 
 ::
 
   WARNING:  08006: connection error: hostname:5432
-  ERROR:  XX000: could not connect to any active placements
+  ERROR:  could not connect to any active placements
   DETAIL:  FATAL:  sorry, too many clients already
-  LOCATION:  OpenCopyConnections, multi_copy.c:884
 
 Resolution
 ~~~~~~~~~~

--- a/sharding/data_modeling.rst
+++ b/sharding/data_modeling.rst
@@ -7,7 +7,7 @@ Citus uses the distribution column in distributed tables to assign table rows to
 
 If the distribution columns are chosen correctly, then related data will group together on the same physical nodes, making queries fast and adding support for all SQL features. If the columns are chosen incorrectly, the system will run needlessly slowly, and won't be able to support all SQL features across nodes.
 
-This section gives distribution column tips for the two most common Citus scenarios. It concludes by going in depth on "co-location," the desirable grouping of data on nodes.
+This section gives distribution column tips for the two most common Citus scenarios. It concludes by going in-depth on "co-location," the desirable grouping of data on nodes.
 
 .. _distributing_by_tenant_id:
 
@@ -151,7 +151,7 @@ If our data was in a single PostgreSQL node, we could easily express our query u
   GROUP BY page_id;
 
 
-As long as the `working set <https://en.wikipedia.org/wiki/Working_set>`_ for this query fits in memory, this is an appropriate solution for many application since it offers maximum flexibility. However, even if you don’t need to scale yet, it can be useful to consider the implications of scaling out on your data model.
+As long as the `working set <https://en.wikipedia.org/wiki/Working_set>`_ for this query fits in memory, this is an appropriate solution for many applications since it offers maximum flexibility. However, even if you don’t need to scale yet, it can be useful to consider the implications of scaling out on your data model.
 
 Distributing tables by ID
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I tested the _Quick Tutorials_, _Develop_ and _FAQ_ sections.
As a result: some outdated outputs, table descriptions. There is also a change in the default of `citus.node_connection_timeout`, and some small typos.