### PR TITLE
Use postgres 13 with citus 9.5

### DIFF
--- a/admin_guide/upgrading_citus.rst
+++ b/admin_guide/upgrading_citus.rst
@@ -15,22 +15,22 @@ Upgrading the Citus version requires first obtaining the new Citus extension and
 Patch Version Upgrade
 ---------------------
 
-To upgrade a Citus version to its latest patch, issue a standard upgrade command for your package manager. Assuming version 9.5 is currently installed on Postgres 12:
+To upgrade a Citus version to its latest patch, issue a standard upgrade command for your package manager. Assuming version 9.5 is currently installed on Postgres 13:
 
 **Ubuntu or Debian**
 
 .. code-block:: bash
 
   sudo apt-get update
-  sudo apt-get install --only-upgrade postgresql-12-citus-9.5
+  sudo apt-get install --only-upgrade postgresql-13-citus-9.5
   sudo service postgresql restart
 
 **Fedora, CentOS, or Red Hat**
 
 .. code-block:: bash
 
-  sudo yum update citus95_12
-  sudo service postgresql-12 restart
+  sudo yum update citus95_13
+  sudo service postgresql-13 restart
 
 .. _major_minor_upgrade:
 

--- a/installation/multi_machine_debian.rst
+++ b/installation/multi_machine_debian.rst
@@ -26,12 +26,12 @@ Steps to be executed on all nodes
 ::
 
   # install the server and initialize db
-  sudo apt-get -y install postgresql-12-citus-9.5
+  sudo apt-get -y install postgresql-13-citus-9.5
 
   # preload citus extension
-  sudo pg_conftool 12 main set shared_preload_libraries citus
+  sudo pg_conftool 13 main set shared_preload_libraries citus
 
-This installs centralized configuration in `/etc/postgresql/12/main`, and creates a database in `/var/lib/postgresql/12/main`.
+This installs centralized configuration in `/etc/postgresql/13/main`, and creates a database in `/var/lib/postgresql/13/main`.
 
 .. _post_enterprise_deb:
 
@@ -41,11 +41,11 @@ Before starting the database let's change its access permissions. By default the
 
 ::
 
-  sudo pg_conftool 12 main set listen_addresses '*'
+  sudo pg_conftool 13 main set listen_addresses '*'
 
 ::
 
-  sudo vi /etc/postgresql/12/main/pg_hba.conf
+  sudo vi /etc/postgresql/13/main/pg_hba.conf
 
 ::
 

--- a/installation/multi_machine_rhel.rst
+++ b/installation/multi_machine_rhel.rst
@@ -26,13 +26,13 @@ Steps to be executed on all nodes
 ::
 
   # install PostgreSQL with Citus extension
-  sudo yum install -y citus95_12
+  sudo yum install -y citus95_13
   # initialize system database (using RHEL 6 vs 7 method as necessary)
-  sudo service postgresql-12 initdb || sudo /usr/pgsql-12/bin/postgresql-12-setup initdb
+  sudo service postgresql-13 initdb || sudo /usr/pgsql-13/bin/postgresql-13-setup initdb
   # preload citus extension
-  echo "shared_preload_libraries = 'citus'" | sudo tee -a /var/lib/pgsql/12/data/postgresql.conf
+  echo "shared_preload_libraries = 'citus'" | sudo tee -a /var/lib/pgsql/13/data/postgresql.conf
 
-PostgreSQL adds version-specific binaries in `/usr/pgsql-12/bin`, but you'll usually just need psql, whose latest version is added to your path, and managing the server itself can be done with the *service* command.
+PostgreSQL adds version-specific binaries in `/usr/pgsql-13/bin`, but you'll usually just need psql, whose latest version is added to your path, and managing the server itself can be done with the *service* command.
 
 .. _post_enterprise_rhel:
 
@@ -42,7 +42,7 @@ Before starting the database let's change its access permissions. By default the
 
 ::
 
-  sudo vi /var/lib/pgsql/12/data/postgresql.conf
+  sudo vi /var/lib/pgsql/13/data/postgresql.conf
 
 ::
 
@@ -51,7 +51,7 @@ Before starting the database let's change its access permissions. By default the
 
 ::
 
-  sudo vi /var/lib/pgsql/12/data/pg_hba.conf
+  sudo vi /var/lib/pgsql/13/data/pg_hba.conf
 
 ::
 
@@ -71,9 +71,9 @@ Before starting the database let's change its access permissions. By default the
 ::
 
   # start the db server
-  sudo service postgresql-12 restart
+  sudo service postgresql-13 restart
   # and make it start automatically when computer does
-  sudo chkconfig postgresql-12 on
+  sudo chkconfig postgresql-13 on
 
 You must add the Citus extension to **every database** you would like to use in a cluster. The following example adds the extension to the default database which is named `postgres`.
 

--- a/installation/single_machine_debian.rst
+++ b/installation/single_machine_debian.rst
@@ -7,7 +7,7 @@ Ubuntu or Debian
 
 This section describes the steps needed to set up a single-node Citus cluster on your own Linux machine from deb packages.
 
-**1. Install PostgreSQL 12 and the Citus extension**
+**1. Install PostgreSQL 13 and the Citus extension**
 
 ::
 
@@ -15,7 +15,7 @@ This section describes the steps needed to set up a single-node Citus cluster on
   curl https://install.citusdata.com/community/deb.sh | sudo bash
 
   # install the server and initialize db
-  sudo apt-get -y install postgresql-12-citus-9.5
+  sudo apt-get -y install postgresql-13-citus-9.5
 
 
 .. _post_install:
@@ -32,7 +32,7 @@ Let's create directories for those nodes to store their data. For convenience in
   sudo su - postgres
 
   # include path to postgres binaries
-  export PATH=$PATH:/usr/lib/postgresql/12/bin
+  export PATH=$PATH:/usr/lib/postgresql/13/bin
 
   cd ~
   mkdir -p citus/coordinator citus/worker1 citus/worker2

--- a/installation/single_machine_rhel.rst
+++ b/installation/single_machine_rhel.rst
@@ -7,7 +7,7 @@ Fedora, CentOS, or Red Hat
 
 This section describes the steps needed to set up a single-node Citus cluster on your own Linux machine from RPM packages.
 
-**1. Install PostgreSQL 12 and the Citus extension**
+**1. Install PostgreSQL 13 and the Citus extension**
 
 ::
 
@@ -15,7 +15,7 @@ This section describes the steps needed to set up a single-node Citus cluster on
   curl https://install.citusdata.com/community/rpm.sh | sudo bash
 
   # install Citus extension
-  sudo yum install -y citus95_12
+  sudo yum install -y citus95_13
 
 .. _post_install:
 
@@ -31,7 +31,7 @@ Let's create directories for those nodes to store their data. For convenience in
   sudo su - postgres
 
   # include path to postgres binaries
-  export PATH=$PATH:/usr/pgsql-12/bin
+  export PATH=$PATH:/usr/pgsql-13/bin
 
   cd ~
   mkdir -p citus/coordinator citus/worker1 citus/worker2


### PR DESCRIPTION
Except for upgrade steps from versions which required older pg versions,
and for the enterprise sections which I have not been able to verify.