### PR TITLE
Docs updates on range distr. and copy from worker in append distr.

### DIFF
--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -436,9 +436,9 @@ Here are examples of functions that can be used within new shard rebalancer stra
       -- example of node_capacity_function
 
       CREATE FUNCTION v2_node_double_capacity(nodeidarg int)
-          RETURNS int AS $$
+          RETURNS real AS $$
           SELECT
-              (CASE WHEN nodename LIKE '%.v2.worker.citusdata.com' THEN 2 ELSE 1 END)
+              (CASE WHEN nodename LIKE '%.v2.worker.citusdata.com' THEN 2.0::float4 ELSE 1.0::float4 END)
           FROM pg_dist_node where nodeid = nodeidarg
           $$ LANGUAGE sql;
   

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -436,7 +436,7 @@ Here are examples of functions that can be used within new shard rebalancer stra
       -- example of node_capacity_function
 
       CREATE FUNCTION v2_node_double_capacity(nodeidarg int)
-          RETURNS boolean AS $$
+          RETURNS int AS $$
           SELECT
               (CASE WHEN nodename LIKE '%.v2.worker.citusdata.com' THEN 2 ELSE 1 END)
           FROM pg_dist_node where nodeid = nodeidarg

--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -243,7 +243,7 @@ will also be rebalanced. If table B does not have a replica identity, the rebala
 fail. Therefore, this function can be useful breaking the implicit colocation in that case.
 
 Both of the arguments should be a hash distributed table, currently we do not support colocation 
-of APPEND or RANGE distributed tables.
+of APPEND distributed tables.
 
 Note that this function does not move any data around physically.
 
@@ -844,7 +844,7 @@ The example below fetches and displays the table metadata for the github_events 
 get_shard_id_for_distribution_column
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-Citus assigns every row of a distributed table to a shard based on the value of the row's distribution column and the table's method of distribution. In most cases the precise mapping is a low-level detail that the database administrator can ignore. However it can be useful to determine a row's shard, either for manual database maintenance tasks or just to satisfy curiosity. The :code:`get_shard_id_for_distribution_column` function provides this info for hash- and range-distributed tables as well as reference tables. It does not work for the append distribution.
+Citus assigns every row of a distributed table to a shard based on the value of the row's distribution column and the table's method of distribution. In most cases the precise mapping is a low-level detail that the database administrator can ignore. However it can be useful to determine a row's shard, either for manual database maintenance tasks or just to satisfy curiosity. The :code:`get_shard_id_for_distribution_column` function provides this info for hash-distributed tables as well as reference tables. It does not work for the append distribution.
 
 Arguments
 ************************


### PR DESCRIPTION
DESCRIPTION: Docs updates on range distr. and copy from worker in append distr.

I provided solutions to some problems I mentioned in release 9.5 doc testing from _Quick Tutorials_, _Develop_ and _FAQ_ sections:

* We don't support COPY from worker nodes on append-distributed tables anymore, so I removed those sections. See https://github.com/citusdata/citus/pull/3261

* As also discussed with @onderkalaci, we don't explain range-based distribution on the docs, so it's better to remove all mentions of range-distributed tables on the docs.

* Lastly, `node_capacity_function` was erroring out due to type mismatch. I simply changed the return type from `boolean` to `int`.
```SQL
-- example of node_capacity_function

CREATE FUNCTION v2_node_double_capacity(nodeidarg int)
    RETURNS boolean AS $$
    SELECT
        (CASE WHEN nodename LIKE '%.v2.worker.citusdata.com' THEN 2 ELSE 1 END)
    FROM pg_dist_node where nodeid = nodeidarg
    $$ LANGUAGE sql;
```
```
ERROR:  return type mismatch in function declared to return boolean
DETAIL:  Actual return type is integer.
CONTEXT:  SQL function "v2_node_double_capacity"
```