### PR TITLE
Docs updates from release test 10.0

### DIFF
--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -539,10 +539,10 @@ After this INSERT, any query needing to connect to node 123 as the user jdoe wil
 
 .. code-block:: postgresql
 
-  -- update user jdoe to use certificate authenticaion
+  -- update user jdoe to use certificate authentication
   UPDATE pg_dist_authinfo
-  WHERE nodeid = 123 AND rolename = 'jdoe'
-  SET authinfo = 'sslcert=/path/to/user.crt sslkey=/path/to/user.key';
+  SET authinfo = 'sslcert=/path/to/user.crt sslkey=/path/to/user.key'
+  WHERE nodeid = 123 AND rolename = 'jdoe';
 
 This changes the user from using a password to use a certificate and keyfile while connecting to node 123 instead. Make sure the user certificate is signed by a certificate that is trusted by the worker you are connecting to and authentication settings on the worker allow for certificate based authentication. Full documentation on how to use client certificates can be found in `the postgres libpq documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-CLIENTCERT>`_.
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -32,14 +32,14 @@ Real-Time Analytics Use-Case
 
 In the :ref:`rt_blurb` use-case, shard count should be related to the total number of cores on the workers. To ensure maximum parallelism, you should create enough shards on each node such that there is at least one shard per CPU core. We typically recommend creating a high number of initial shards, e.g. **2x or 4x the number of current CPU cores**. This allows for future scaling if you add more workers and CPU cores.
 
-However keep in mind that for each query Citus opens one database connection per shard, and these connections are limited. Be careful to keep the shard count small enough that distributed queries won't often have to wait for a connection. Put another way, the connections needed, ``(max concurrent queries * shard count)``, should generally not exceed the total connections possible in the system, ``(number of workers * max_connections per worker)``.
+However, keep in mind that for each query Citus opens one database connection per shard, and these connections are limited. Be careful to keep the shard count small enough that distributed queries won't often have to wait for a connection. Put another way, the connections needed, ``(max concurrent queries * shard count)``, should generally not exceed the total connections possible in the system, ``(number of workers * max_connections per worker)``.
 
 .. _prod_size:
 
 Initial Hardware Size
 =====================
 
-The size of a cluster, in terms of number of nodes and their hardware capacity, is easy to change. (:ref:`Scaling <cloud_scaling>` on Citus Cloud is especially easy.) However you still need to choose an initial size for a new cluster. Here are some tips for a reasonable initial cluster size.
+The size of a cluster, in terms of number of nodes and their hardware capacity, is easy to change. (:ref:`Scaling <cloud_scaling>` on Citus Cloud is especially easy.) However, you still need to choose an initial size for a new cluster. Here are some tips for a reasonable initial cluster size.
 
 Multi-Tenant SaaS Use-Case
 --------------------------
@@ -60,7 +60,7 @@ Real-Time Analytics Use-Case
 Scaling the cluster
 ===================
 
-Citus’s logical sharding based architecture allows you to scale out your cluster without any down time. This section describes how you can add more nodes to your Citus cluster in order to improve query performance / scalability.
+Citus’s logical sharding based architecture allows you to scale out your cluster without any downtime. This section describes how you can add more nodes to your Citus cluster in order to improve query performance / scalability.
 
 .. _adding_worker_node:
 
@@ -139,7 +139,7 @@ As the PostgreSQL docs `explain <https://www.postgresql.org/docs/current/static/
   one. Another unique index (with certain additional requirements) can
   also be set to be the replica identity.
 
-In other words, if your distributed table has a primary key defined then it's ready for shard rebalancing with no extra work. However if it doesn't have a primary key or an explicitly defined replica identity, then attempting to rebalance it will cause an error. For instance:
+In other words, if your distributed table has a primary key defined then it's ready for shard rebalancing with no extra work. However, if it doesn't have a primary key or an explicitly defined replica identity, then attempting to rebalance it will cause an error. For instance:
 
 .. code-block:: sql
 
@@ -221,7 +221,7 @@ However, in some write heavy use cases where the coordinator becomes a performan
 Dealing With Node Failures
 ==========================
 
-In this sub-section, we discuss how you can deal with node failures without incurring any downtime on your Citus cluster. We first discuss how Citus handles worker failures automatically by maintaining multiple replicas of the data. We also briefly describe how users can replicate their shards to bring them to the desired replication factor in case a node is down for a long time. Lastly, we discuss how you can setup redundancy and failure handling mechanisms for the coordinator.
+In this subsection, we discuss how you can deal with node failures without incurring any downtime on your Citus cluster. We first discuss how Citus handles worker failures automatically by maintaining multiple replicas of the data. We also briefly describe how users can replicate their shards to bring them to the desired replication factor in case a node is down for a long time. Lastly, we discuss how you can setup redundancy and failure handling mechanisms for the coordinator.
 
 .. _worker_node_failures:
 
@@ -261,7 +261,7 @@ Tenant Isolation
 
 Citus places table rows into worker shards based on the hashed value of the rows' distribution column. Multiple distribution column values often fall into the same shard. In the Citus multi-tenant use case this means that tenants often share shards.
 
-However sharing shards can cause resource contention when tenants differ drastically in size. This is a common situation for systems with a large number of tenants -- we have observed that the size of tenant data tend to follow a Zipfian distribution as the number of tenants increases. This means there are a few very large tenants, and many smaller ones. To improve resource allocation and make guarantees of tenant QoS it is worthwhile to move large tenants to dedicated nodes.
+However, sharing shards can cause resource contention when tenants differ drastically in size. This is a common situation for systems with a large number of tenants -- we have observed that the size of tenant data tend to follow a Zipfian distribution as the number of tenants increases. This means there are a few very large tenants, and many smaller ones. To improve resource allocation and make guarantees of tenant QoS it is worthwhile to move large tenants to dedicated nodes.
 
 Citus Enterprise Edition provides the tools to isolate a tenant on a specific node. This happens in two phases: 1) isolating the tenant's data to a new dedicated shard, then 2) moving the shard to the desired node. To understand the process it helps to know precisely how rows of data are assigned to shards.
 
@@ -399,7 +399,7 @@ Results:
 
 We can see that Citus uses the adaptive executor most commonly to run queries. This executor fragments the query into constituent queries to run on relevant nodes, and combines the results on the coordinator node. In the case of the second query (filtering by the distribution column ``id = $1``), Citus determined that it needed the data from just one node. Lastly, we can see that the ``insert into foo select…`` statement ran with the insert-select executor which provides flexibility to run these kind of queries.
 
-So far the information in this view doesn't give us anything we couldn't already learn by running the ``EXPLAIN`` command for a given query. However in addition to getting information about individual queries, the ``citus_stat_statements`` view allows us to answer questions such as "what percentage of queries in the cluster are scoped to a single tenant?"
+So far the information in this view doesn't give us anything we couldn't already learn by running the ``EXPLAIN`` command for a given query. However, in addition to getting information about individual queries, the ``citus_stat_statements`` view allows us to answer questions such as "what percentage of queries in the cluster are scoped to a single tenant?"
 
 .. code-block:: postgresql
 
@@ -410,7 +410,6 @@ So far the information in this view doesn't give us anything we couldn't already
 
 ::
 
-  .
    sum | single_tenant
   -----+---------------
      2 | f
@@ -444,13 +443,13 @@ The pg_stat_statements view limits the number of statements it tracks, and the d
 
 There are three ways to help synchronize the views, and all three can be used together.
 
-1. Have the maintenance daemon periodically sync the citus and pg stats. The GUC ``citus.stats_statements_purge_interval`` sets time in seconds for the sync. A value of 0 disables periodic syncs.
-2. Adjust the number of entries in citus_stat_statements. The ``citus.stats_statements_max`` GUC removes old entries when new ones cross the threshold. The default value is 50K, and the highest allowable value is 10M. Note that each entry costs about 140 bytes in shared memory so set the value wisely.
+1. Have the maintenance daemon periodically sync the citus and pg stats. The GUC ``citus.stat_statements_purge_interval`` sets time in seconds for the sync. A value of 0 disables periodic syncs.
+2. Adjust the number of entries in citus_stat_statements. The ``citus.stat_statements_max`` GUC removes old entries when new ones cross the threshold. The default value is 50K, and the highest allowable value is 10M. Note that each entry costs about 140 bytes in shared memory so set the value wisely.
 3. Increase ``pg_stat_statements.max``. Its default value is 5000, and could be increased to 10K, 20K or even 50K without much overhead. This is most beneficial when there is more local (i.e. coordinator) query workload.
 
 .. note::
 
-   Changing ``pg_stat_statements.max`` or ``citus.stat_statements_max`` requires restarting the PostgreSQL service. Changing ``citus.stats_statements_purge_interval``, on the other hand, will come info effect with a call to `pg_reload_conf() <https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL>`_.
+   Changing ``pg_stat_statements.max`` or ``citus.stat_statements_max`` requires restarting the PostgreSQL service. Changing ``citus.stat_statements_purge_interval``, on the other hand, will come into effect with a call to `pg_reload_conf() <https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL>`_.
 
 Resource Conservation
 =====================
@@ -509,7 +508,7 @@ To set non-sensitive libpq connection parameters to be used for all node connect
 
 There is a whitelist of parameters that the GUC accepts, see the :ref:`node_conninfo <node_conninfo>` reference for details. As of Citus 8.1, the default value for node_conninfo is ``sslmode=require``, which prevents unencrypted communication between nodes. If your cluster was originally created before Citus 8.1 the value will be ``sslmode=prefer``. After setting up self-signed certificates on all nodes it's recommended to change this setting to ``sslmode=require``.
 
-After changing this setting it is important to reload the postgres configuration. Even though the changed setting might be visible in all sessions, the setting is only consulted by Citus when new connections are established. When a reload signal is received citus marks all existing connections to be closed which causes a reconnect after running transactions have been completed.
+After changing this setting it is important to reload the postgres configuration. Even though the changed setting might be visible in all sessions, the setting is only consulted by Citus when new connections are established. When a reload signal is received, Citus marks all existing connections to be closed which causes a reconnect after running transactions have been completed.
 
 .. code-block:: postgresql
 
@@ -544,7 +543,7 @@ After this INSERT, any query needing to connect to node 123 as the user jdoe wil
 
 This changes the user from using a password to use a certificate and keyfile while connecting to node 123 instead. Make sure the user certificate is signed by a certificate that is trusted by the worker you are connecting to and authentication settings on the worker allow for certificate based authentication. Full documentation on how to use client certificates can be found in `the postgres libpq documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-CLIENTCERT>`_.
 
-Changing ``pg_dist_authinof`` does not force any existing connection to reconnect.
+Changing ``pg_dist_authinfo`` does not force any existing connection to reconnect.
 
 Setup Certificate Authority signed certificates
 -----------------------------------------------
@@ -612,7 +611,7 @@ To verify the connections from the coordinator to the workers are encrypted you 
 Increasing Worker Security
 --------------------------
 
-For your convenience getting started, our multi-node installation instructions direct you to set up the :code:`pg_hba.conf` on the workers with its `authentication method <https://www.postgresql.org/docs/current/static/auth-methods.html>`_ set to "trust" for local network connections. However you might desire more security.
+For your convenience getting started, our multi-node installation instructions direct you to set up the :code:`pg_hba.conf` on the workers with its `authentication method <https://www.postgresql.org/docs/current/static/auth-methods.html>`_ set to "trust" for local network connections. However, you might desire more security.
 
 To require that all connections supply a hashed password, update the PostgreSQL :code:`pg_hba.conf` on every worker node with something like this:
 
@@ -628,7 +627,7 @@ To require that all connections supply a hashed password, update the PostgreSQL 
   hostssl    all             all             127.0.0.1/32            md5
   hostssl    all             all             ::1/128                 md5
 
-The coordinator node needs to know roles' passwords in order to communicate with the workers. In Citus Enterprise the ``pg_dist_authinfo`` table can provide that information, as discussed earlier. However in Citus Community Edition the authentication information has to be maintained in a `.pgpass <https://www.postgresql.org/docs/current/static/libpq-pgpass.html>`_ file. Edit .pgpass in the postgres user's home directory, with a line for each combination of worker address and role:
+The coordinator node needs to know roles' passwords in order to communicate with the workers. In Citus Enterprise the ``pg_dist_authinfo`` table can provide that information, as discussed earlier. However, in Citus Community Edition the authentication information has to be maintained in a `.pgpass <https://www.postgresql.org/docs/current/static/libpq-pgpass.html>`_ file. Edit .pgpass in the postgres user's home directory, with a line for each combination of worker address and role:
 
 ::
 
@@ -749,7 +748,7 @@ In addition to our core Citus extension, we also maintain several others:
 Creating a New Database
 =======================
 
-Each PostgreSQL server can hold `multiple databases <https://www.postgresql.org/docs/current/static/manage-ag-overview.html>`_. However new databases do not inherit the extensions of any others; all desired extensions must be added afresh. To run Citus on a new database, you'll need to create the database on the coordinator and workers, create the Citus extension within that database, and register the workers in the coordinator database.
+Each PostgreSQL server can hold `multiple databases <https://www.postgresql.org/docs/current/static/manage-ag-overview.html>`_. However, new databases do not inherit the extensions of any others; all desired extensions must be added afresh. To run Citus on a new database, you'll need to create the database on the coordinator and workers, create the Citus extension within that database, and register the workers in the coordinator database.
 
 Connect to each of the worker nodes and run:
 

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -413,6 +413,7 @@ So far the information in this view doesn't give us anything we couldn't already
 
 ::
 
+  .
    sum | single_tenant
   -----+---------------
      2 | f
@@ -724,7 +725,7 @@ Now roles ``tenant_1`` and ``tenant_2`` get different results for their queries:
 
   INSERT INTO events VALUES (3,3,'surprise');
   /*
-  ERROR:  42501: new row violates row-level security policy for table "events_102055"
+  ERROR:  new row violates row-level security policy for table "events_102055"
   */
 
 .. _sql_extensions:

--- a/admin_guide/cluster_management.rst
+++ b/admin_guide/cluster_management.rst
@@ -147,6 +147,9 @@ In other words, if your distributed table has a primary key defined then it's re
   CREATE TABLE test_table (key int not null, value text not null);
   SELECT create_distributed_table('test_table', 'key');
 
+  -- add a new worker node to simulate need for
+  -- shard rebalancing
+  
   -- running shard rebalancer with default behavior
   SELECT rebalance_table_shards('test_table');
 

--- a/admin_guide/table_management.rst
+++ b/admin_guide/table_management.rst
@@ -165,6 +165,7 @@ contain the same data, and compare:
 
 ::
 
+  .
    row_size | columnar_size
   ----------+---------------
       16384 |         24576

--- a/admin_guide/table_management.rst
+++ b/admin_guide/table_management.rst
@@ -56,7 +56,7 @@ In PostgreSQL (and other MVCC databases), an UPDATE or DELETE of a row does not 
 
 It’s not just user queries which scale in a distributed database, vacuuming does too. In PostgreSQL big busy tables have great potential to bloat, both from lower sensitivity to PostgreSQL's vacuum scale factor parameter, and generally because of the extent of their row churn. Splitting a table into distributed shards means both that individual shards are smaller tables and that auto-vacuum workers can parallelize over different parts of the table on different machines. Ordinarily auto-vacuum can only run one worker per table.
 
-Due to the above, auto-vacuum operations on a Citus cluster are probably good enough for most cases. However for tables with particular workloads, or companies with certain "safe" hours to schedule a vacuum, it might make more sense to manually vacuum a table rather than leaving all the work to auto-vacuum.
+Due to the above, auto-vacuum operations on a Citus cluster are probably good enough for most cases. However, for tables with particular workloads, or companies with certain "safe" hours to schedule a vacuum, it might make more sense to manually vacuum a table rather than leaving all the work to auto-vacuum.
 
 To vacuum a table, simply run this on the coordinator node:
 
@@ -165,7 +165,6 @@ contain the same data, and compare:
 
 ::
 
-  .
    row_size | columnar_size
   ----------+---------------
       16384 |         24576
@@ -193,7 +192,7 @@ Gotchas
   .. code-block:: postgresql
 
     BEGIN;
-    CREATE TABLE foo_compacted (LIKE foo) USING COLUMNAR;
+    CREATE TABLE foo_compacted (LIKE foo) USING columnar;
     INSERT INTO foo_compacted SELECT * FROM foo;
     DROP TABLE foo;
     ALTER TABLE foo_compacted RENAME TO foo;

--- a/cloud/additional_fork.rst
+++ b/cloud/additional_fork.rst
@@ -24,7 +24,7 @@ A fork is a great place to do experiments. Do you think that denormalizing a tab
 
 In such cases, what you need is a temporary copy of the production database. But it would take forever to copy, say, 500GB of data to a new formation. Not to mention that making the copy would slow down the production database. Copying the database in the old fashioned way is not a good idea.
 
-However a Citus fork is different. Forking fetches write-ahead log data from S3 and has zero effect on the production load. You can apply your experiments to the fork and destroy it when you're done.
+However, a Citus fork is different. Forking fetches write-ahead log data from S3 and has zero effect on the production load. You can apply your experiments to the fork and destroy it when you're done.
 
 Another use of forking is to enable complex analytical queries. Sometimes data analysts want to have access to live production data for complex queries that would take hours. What's more, they sometimes want to bend the data: denormalize tables, create aggregations, create an extra index or even pull all the data onto one machine.
 

--- a/cloud/performance.rst
+++ b/cloud/performance.rst
@@ -7,7 +7,7 @@ Scaling
 
 Citus Cloud provides self-service scaling to deal with increased load. The web interface makes it easy to either add new worker nodes or increase existing nodes' memory and CPU capacity.
 
-For most cases either approach to scaling is fine and will improve performance. However there are times you may want to choose one over the other. If the cluster is reaching its disk limit then adding more nodes is the best choice. Alternately, if there is still a lot of headroom on disk but performance is suffering, then scaling node RAM and processing power is the way to go.
+For most cases either approach to scaling is fine and will improve performance. However, there are times you may want to choose one over the other. If the cluster is reaching its disk limit then adding more nodes is the best choice. Alternately, if there is still a lot of headroom on disk but performance is suffering, then scaling node RAM and processing power is the way to go.
 
 Both adjustments are available in the formation configuration panel of the settings tab:
 
@@ -60,7 +60,7 @@ You can go to the "Rebalancer" tab in the Cloud console to see the shard balance
 .. image:: ../images/cloud-rebalance-unnecessary.png
     :alt: gray squares representing evently balanced shards
 
-However if the shards could be placed more evenly, such as after a new node has been added to the cluster, the page will show a "Rebalance recommended."
+However, if the shards could be placed more evenly, such as after a new node has been added to the cluster, the page will show a "Rebalance recommended."
 
 .. image:: ../images/cloud-rebalance-recommended.png
     :alt: squares of different colors representing unbalanced shards

--- a/cloud/security.rst
+++ b/cloud/security.rst
@@ -93,7 +93,7 @@ The new :code:`reports` role starts with no privileges, except "usage" on the pu
 
   GRANT SELECT ON mytable TO reports;
 
-If ``mytable`` is in the public schema this will suffice. However if the table is in another schema, there is one more step. See :ref:`grant_usage` below.
+If ``mytable`` is in the public schema this will suffice. However, if the table is in another schema, there is one more step. See :ref:`grant_usage` below.
 
 You can confirm the privileges by consulting the information schema:
 

--- a/cloud/upgrades.rst
+++ b/cloud/upgrades.rst
@@ -27,4 +27,4 @@ When the new nodes have caught up (and during a maintenance window if one has be
 .. image:: ../images/cloud-upgrade-complete.png
     :alt: message saying that the formation is up to date
 
-If :ref:`high-availability replication <ha>` is enabled, Citus Cloud will automatically create new standby servers. However :ref:`follower replicas <cloud_followers>` will not receive the updates and must be manually destroyed and recreated.
+If :ref:`high-availability replication <ha>` is enabled, Citus Cloud will automatically create new standby servers. However, :ref:`follower replicas <cloud_followers>` will not receive the updates and must be manually destroyed and recreated.

--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -206,7 +206,7 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 Reference table shards must be placed on all nodes which have distributed
 tables. By default, reference table shards are copied to a node at node
 activation time, that is, when such functions as :ref:`citus_add_node` or
-:ref:`citus_activate_node` are called. However node activation might be an
+:ref:`citus_activate_node` are called. However, node activation might be an
 inconvenient time to copy the placements, because it can take a long time when
 there are large reference tables.
 
@@ -338,7 +338,7 @@ The supported values are:
 citus.enable_repartition_joins (boolean)
 ****************************************
 
-Ordinarily, attempting to perform :ref:`repartition_joins` with the adaptive executor will fail with an error message. However setting ``citus.enable_repartition_joins`` to true allows Citus to perform the join. The default value is false.
+Ordinarily, attempting to perform :ref:`repartition_joins` with the adaptive executor will fail with an error message. However, setting ``citus.enable_repartition_joins`` to true allows Citus to perform the join. The default value is false.
 
 .. _enable_repartitioned_insert_select:
 

--- a/develop/api_metadata.rst
+++ b/develop/api_metadata.rst
@@ -167,7 +167,7 @@ The pg_dist_placement table tracks the location of shard replicas on worker node
        102010 |          1 |           0 | localhost |    12345 |           6
        102011 |          1 |           0 | localhost |    12345 |           7
 
-  That information is now available by joining pg_dist_placement with :ref:`pg_dist_node <pg_dist_node>` on the groupid. For compatibility Citus still provides pg_dist_shard_placement as a view. However we recommend using the new, more normalized, tables when possible.
+  That information is now available by joining pg_dist_placement with :ref:`pg_dist_node <pg_dist_node>` on the groupid. For compatibility Citus still provides pg_dist_shard_placement as a view. However, we recommend using the new, more normalized, tables when possible.
 
 
 Shard Placement States

--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -34,7 +34,7 @@ to be distributed. Permissible values are append or hash, and defaults to 'hash'
 **colocate_with:** (Optional) include current table in the co-location group of another table. By default tables are co-located when they are distributed by columns of the same type, have the same shard count, and have the same replication factor.
 If you want to break this colocation later, you can use :ref:`update_distributed_table_colocation <update_distributed_table_colocation>`. Possible values for :code:`colocate_with` are :code:`default`, :code:`none` to start a new co-location group, or the name of another table to co-locate with that table.  (See :ref:`colocation_groups`.)
 
-Keep in mind that the default value of ``colocate_with`` does implicit co-location. As :ref:`colocation` explains, this can be a great thing when tables are related or will be joined. However when two tables are unrelated but happen to use the same datatype for their distribution columns, accidentally co-locating them can decrease performance during :ref:`shard rebalancing <shard_rebalancing>`. The table shards will be moved together unnecessarily in a "cascade."
+Keep in mind that the default value of ``colocate_with`` does implicit co-location. As :ref:`colocation` explains, this can be a great thing when tables are related or will be joined. However, when two tables are unrelated but happen to use the same datatype for their distribution columns, accidentally co-locating them can decrease performance during :ref:`shard rebalancing <shard_rebalancing>`. The table shards will be moved together unnecessarily in a "cascade."
 If you want to break this implicit colocation, you can use :ref:`update_distributed_table_colocation <update_distributed_table_colocation>`.
 
 If a new distributed table is not related to other tables, it's best to specify ``colocate_with => 'none'``.
@@ -640,7 +640,7 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
     This function requires database superuser access to run.
 
 The :code:`citus_add_inactive_node` function, similar to :ref:`citus_add_node`,
-registers a new node in :code:`pg_dist_node`. However it marks the new
+registers a new node in :code:`pg_dist_node`. However, it marks the new
 node as inactive, meaning no shards will be placed there. Also it does
 *not* copy reference tables to the new node.
 
@@ -902,7 +902,7 @@ The example below fetches and displays the table metadata for the github_events 
 get_shard_id_for_distribution_column
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-Citus assigns every row of a distributed table to a shard based on the value of the row's distribution column and the table's method of distribution. In most cases the precise mapping is a low-level detail that the database administrator can ignore. However it can be useful to determine a row's shard, either for manual database maintenance tasks or just to satisfy curiosity. The :code:`get_shard_id_for_distribution_column` function provides this info for hash-distributed tables as well as reference tables. It does not work for the append distribution.
+Citus assigns every row of a distributed table to a shard based on the value of the row's distribution column and the table's method of distribution. In most cases the precise mapping is a low-level detail that the database administrator can ignore. However, it can be useful to determine a row's shard, either for manual database maintenance tasks or just to satisfy curiosity. The :code:`get_shard_id_for_distribution_column` function provides this info for hash-distributed tables as well as reference tables. It does not work for the append distribution.
 
 Arguments
 ************************

--- a/develop/migration_mt_django.rst
+++ b/develop/migration_mt_django.rst
@@ -78,7 +78,7 @@ It generates these underlying SQL queries:
   FROM myapp_task
   WHERE project_id IN (1, 2, 3);
 
-However the second query would go faster with an extra filter:
+However, the second query would go faster with an extra filter:
 
 .. code-block:: postgresql
 

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -217,7 +217,7 @@ Citus propagates most `ALTER TABLE <https://www.postgresql.org/docs/current/stat
 
   ALTER TABLE products ALTER COLUMN price SET DEFAULT 7.77;
 
-Significant changes to an existing column like renaming it or changing its data type are fine too. However the data type of the :ref:`distribution column <distributed_data_modeling>` cannot be altered. This column determines how table data distributes through the Citus cluster, and modifying its data type would require moving the data.
+Significant changes to an existing column like renaming it or changing its data type are fine too. However, the data type of the :ref:`distribution column <distributed_data_modeling>` cannot be altered. This column determines how table data distributes through the Citus cluster, and modifying its data type would require moving the data.
 
 Attempting to do so causes an error:
 
@@ -233,7 +233,7 @@ Attempting to do so causes an error:
   ERROR:  cannot execute ALTER TABLE command involving partition column
   */
 
-However there's a workaround of re-creating the distributed table. See :ref:`change_dist_col`.
+However, there's a workaround of re-creating the distributed table. See :ref:`change_dist_col`.
 
 Adding/Removing Constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -327,7 +327,7 @@ In the course of time imagine that a few non-addresses get into the table.
    INSERT INTO users VALUES
       ('foo@example.com'), ('hacker12@aol.com'), ('lol');
 
-We would like to validate the addresses, but PostgreSQL does not ordinarily allow us to add a CHECK constraint that fails for existing rows. However it *does* allow a constraint marked not valid:
+We would like to validate the addresses, but PostgreSQL does not ordinarily allow us to add a CHECK constraint that fails for existing rows. However, it *does* allow a constraint marked not valid:
 
 .. code-block:: postgres
 
@@ -385,4 +385,4 @@ Adding an index takes a write lock, which can be undesirable in a multi-tenant "
 Manual Modification
 ~~~~~~~~~~~~~~~~~~~
 
-Currently other DDL commands are not auto-propagated, however you can propagate the changes manually. See :ref:`manual_prop`.
+Currently other DDL commands are not auto-propagated, however, you can propagate the changes manually. See :ref:`manual_prop`.

--- a/develop/reference_dml.rst
+++ b/develop/reference_dml.rst
@@ -76,7 +76,7 @@ First download our example github_events dataset by running:
     wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-{0..5}.csv.gz
     gzip -d github_events-2015-01-01-*.gz
 
-Then, you can copy the data using psql:
+Then, you can copy the data using psql (note that this data requires the database to have UTF8 encoding):
 
 .. code-block:: psql
 

--- a/develop/reference_processing.rst
+++ b/develop/reference_processing.rst
@@ -57,7 +57,7 @@ For example, having subqueries in a WHERE clause sometimes cannot execute inline
   )
   GROUP BY page_id;
 
-The executor would like to run a fragment of this query against each shard by page_id, counting distinct host_ips, and combining the results on the coordinator. However the LIMIT in the subquery means the subquery cannot be executed as part of the fragment. By recursively planning the query Citus can run the subquery separately, push the results to all workers, run the main fragment query, and pull the results back to the coordinator. The "push-pull" design supports subqueries like the one above.
+The executor would like to run a fragment of this query against each shard by page_id, counting distinct host_ips, and combining the results on the coordinator. However, the LIMIT in the subquery means the subquery cannot be executed as part of the fragment. By recursively planning the query Citus can run the subquery separately, push the results to all workers, run the main fragment query, and pull the results back to the coordinator. The "push-pull" design supports subqueries like the one above.
 
 Let's see this in action by reviewing the `EXPLAIN <https://www.postgresql.org/docs/current/static/sql-explain.html>`_ output for this query. It's fairly involved:
 

--- a/develop/reference_propagation.rst
+++ b/develop/reference_propagation.rst
@@ -5,7 +5,7 @@ Manual Query Propagation
 
 When the user issues a query, the Citus coordinator partitions it into smaller query fragments where each query fragment can be run independently on a worker shard. This allows Citus to distribute each query across the cluster.
 
-However the way queries are partitioned into fragments (and which queries are propagated at all) varies by the type of query. In some advanced situations it is useful to manually control this behavior. Citus provides utility functions to propagate SQL to workers, shards, or placements.
+However, the way queries are partitioned into fragments (and which queries are propagated at all) varies by the type of query. In some advanced situations it is useful to manually control this behavior. Citus provides utility functions to propagate SQL to workers, shards, or placements.
 
 Manual query propagation bypasses coordinator logic, locking, and any other consistency checks. These functions are available as a last resort to allow statements which Citus otherwise does not run natively. Use them carefully to avoid data inconsistency and deadlocks.
 

--- a/develop/reference_sql.rst
+++ b/develop/reference_sql.rst
@@ -116,7 +116,7 @@ Certain users already store their data as HLL columns. In such cases, they can d
 Estimating Top N Items
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Calculating the first *n* elements in a set by applying count, sort, and limit is simple. However as data sizes increase, this method becomes slow and resource intensive. It's more efficient to use an approximation.
+Calculating the first *n* elements in a set by applying count, sort, and limit is simple. However, as data sizes increase, this method becomes slow and resource intensive. It's more efficient to use an approximation.
 
 The open source `TopN extension <https://github.com/citusdata/postgresql-topn>`_ for Postgres enables fast approximate results to "top-n" queries. The extension materializes the top values into a JSON data type. TopN can incrementally update these top values, or merge them on-demand across different time intervals.
 

--- a/develop/reference_workarounds.rst
+++ b/develop/reference_workarounds.rst
@@ -7,7 +7,7 @@ As Citus provides distributed functionality by extending PostgreSQL, it is compa
 
 Citus has 100% SQL coverage for any queries it is able to execute on a single worker node. These kind of queries are common in :ref:`mt_use_case` when accessing information about a single tenant.
 
-Even cross-node queries (used for parallel computations) support most SQL features. However some SQL features are not supported for queries which combine information from multiple nodes.
+Even cross-node queries (used for parallel computations) support most SQL features. However, some SQL features are not supported for queries which combine information from multiple nodes.
 
 **Limitations for Cross-Node SQL Queries:**
 

--- a/extra/triggers.rst
+++ b/extra/triggers.rst
@@ -24,7 +24,7 @@ Suppose that for each row in a table we wish to record the user who last updated
   );
   SELECT create_distributed_table('events', 'id');
 
-However this is a distributed table, so a single trigger on the coordinator for the table won't work. We need to create a trigger for each of the table placements.
+However, this is a distributed table, so a single trigger on the coordinator for the table won't work. We need to create a trigger for each of the table placements.
 
 .. code-block:: postgresql
 

--- a/faq/faq.rst
+++ b/faq/faq.rst
@@ -156,7 +156,7 @@ The Citus coordinator node metadata tables contain this information. See :ref:`f
 Can I distribute a table by multiple keys?
 ------------------------------------------
 
-No, you must choose a single column per table as the distribution column. A common scenario where people want to distribute by two columns is for timeseries data. However for this case we recommend using a hash distribution on a non-time column, and combining this with PostgreSQL partitioning on the time column, as described in :ref:`distributing_hash_time`.
+No, you must choose a single column per table as the distribution column. A common scenario where people want to distribute by two columns is for timeseries data. However, for this case we recommend using a hash distribution on a non-time column, and combining this with PostgreSQL partitioning on the time column, as described in :ref:`distributing_hash_time`.
 
 Why does pg_relation_size report zero bytes for a distributed table?
 --------------------------------------------------------------------
@@ -195,7 +195,7 @@ At this time Amazon does not support running Citus directly on top of Amazon RDS
 What is the state of Citus on AWS?
 ----------------------------------
 
-Existing customers of :ref:`Citus Cloud <cloud_overview>` can provision a Citus cluster on Amazon Web Services. However we are no longer accepting new signups for Citus Cloud.
+Existing customers of :ref:`Citus Cloud <cloud_overview>` can provision a Citus cluster on Amazon Web Services. However, we are no longer accepting new signups for Citus Cloud.
 
 For a fully managed Citus database-as-a-service, try `Azure Database for PostgreSQL - Hyperscale (Citus) <https://docs.microsoft.com/en-us/azure/postgresql/overview#azure-database-for-postgresql---hyperscale-citus-preview>`_.
 

--- a/performance/performance_tuning.rst
+++ b/performance/performance_tuning.rst
@@ -63,7 +63,7 @@ This tells you several things. To begin with there are thirty-two shards, and th
 
 ::
 
-  ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+  ->  Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
     Task Count: 32
 
 Next it picks one of the workers and shows you more about how the query behaves there. It indicates the host, port, database, and the query that was sent to the worker so you can connect to the worker directly and try the query if desired:
@@ -188,7 +188,7 @@ For higher INSERT performance, the factor which impacts insert rates the most is
 Subquery/CTE Network Overhead
 =============================
 
-In the best case Citus can execute queries containing subqueries and CTEs in a single step. This is usually because both the main query and subquery filter by tables' distribution column in the same way, and can be pushed down to worker nodes together. However Citus is sometimes forced to execute subqueries *before* executing the main query, copying the intermediate subquery results to other worker nodes for use by the main query. This technique is called :ref:`push_pull_execution`.
+In the best case Citus can execute queries containing subqueries and CTEs in a single step. This is usually because both the main query and subquery filter by tables' distribution column in the same way, and can be pushed down to worker nodes together. However, Citus is sometimes forced to execute subqueries *before* executing the main query, copying the intermediate subquery results to other worker nodes for use by the main query. This technique is called :ref:`push_pull_execution`.
 
 It's important to be aware when subqueries are executed in a separate step, and avoid sending too much data between worker nodes. The network overhead will hurt performance. The EXPLAIN command allows you to discover how queries will be executed, including whether multiple steps are required. For a detailed example see :ref:`push_pull_execution`.
 
@@ -317,7 +317,7 @@ rows (such as ``select * from table``), or when result columns use big types
 
 In those cases it can be beneficial to set ``citus.enable_binary_protocol`` to
 ``true``, which will change the encoding of the results to binary, rather than
-using text encoding. Binary encoding significantly reduce bandwidth for types
+using text encoding. Binary encoding significantly reduces bandwidth for types
 that have a compact binary representation, such as ``hll``, ``tdigest``,
 ``timestamp`` and ``double precision``.
 
@@ -326,7 +326,7 @@ Adaptive Executor
 
 Citus' adaptive executor conserves database connections to help reduce resource usage on worker nodes during multi-shard queries. When running a query, the executor begins by using a single -- usually precached -- connection to a remote node. If the query finishes within the time period specified by citus.executor_slow_start_interval, no more connections are required. Otherwise the executor gradually establishes new connections as directed by citus.executor_slow_start_interval. (See also https://docs.citusdata.com/en/latest/develop/api_guc.html#adaptive-executor-configuration)
 
-With the behavior explained above, the executor aims to open optimal number of connections to remote nodes. For short running multi-shard queries, like an index-only-scan on the shards, the executor may use only a single connection and execute all the queries on the shards over a single connection. For longer running multi-shard queries, the executor will keep opening connections to parallelize the execution on the remote nodes. If the queries on the shards take long (such as > 500ms), the executor converges to using one connection per shard (or up to citus.max_adaptive_executor_pool_size), in order to maximize the parallelism.
+With the behavior explained above, the executor aims to open an optimal number of connections to remote nodes. For short running multi-shard queries, like an index-only-scan on the shards, the executor may use only a single connection and execute all the queries on the shards over a single connection. For longer running multi-shard queries, the executor will keep opening connections to parallelize the execution on the remote nodes. If the queries on the shards take long (such as > 500ms), the executor converges to using one connection per shard (or up to citus.max_adaptive_executor_pool_size), in order to maximize the parallelism.
 
 .. _scaling_data_ingestion:
 
@@ -340,7 +340,7 @@ Real-time Insert and Updates
 
 On the Citus coordinator, you can perform INSERT, INSERT .. ON CONFLICT, UPDATE, and DELETE commands directly on distributed tables. When you issue one of these commands, the changes are immediately visible to the user.
 
-When you run an INSERT (or another ingest command), Citus first finds the right shard placements based on the value in the distribution column. Citus then connects to the worker nodes storing the shard placements, and performs an INSERT on each of them. From the perspective of the user, the INSERT takes several milliseconds to process because of the network latency to worker nodes. The Citus coordinator node however can process concurrent INSERTs to reach high throughputs.
+When you run an INSERT (or another ingest command), Citus first finds the right shard placements based on the value in the distribution column. Citus then connects to the worker nodes storing the shard placements, and performs an INSERT on each of them. From the perspective of the user, the INSERT takes several milliseconds to process because of the network latency to worker nodes. The Citus coordinator node, however, can process concurrent INSERTs to reach high throughputs.
 
 Insert Throughput
 -----------------

--- a/reference/common_errors.rst
+++ b/reference/common_errors.rst
@@ -33,7 +33,7 @@ Resolution
 
 To fix, check that the worker is accepting connections, and that DNS is correctly resolving.
 
-Canceling the transaction since it was involved in a distributed deadlock
+Cancelling the transaction since it was involved in a distributed deadlock
 -------------------------------------------------------------------------
 
 Deadlocks can happen not only in a single-node database, but in a distributed database, caused by queries executing across multiple nodes. Citus has the intelligence to recognize distributed deadlocks and defuse them by aborting one of the queries involved.
@@ -94,7 +94,7 @@ As of Citus 8.1, nodes are required talk to one another using SSL by default. If
 
 However, if a root certificate authority file exists (typically in ``~/.postgresql/root.crt``), then the certificate will be checked unsuccessfully against that CA at connection time. The Postgres documentation about `SSL support <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES>`_ warns:
 
-   For backwards compatibility with earlier versions of PostgreSQL,
+   For backward compatibility with earlier versions of PostgreSQL,
    if a root CA file exists, the behavior of sslmode=require will be
    the same as that of verify-ca, meaning the server certificate is
    validated against the CA. Relying on this behavior is discouraged,

--- a/reference/common_errors.rst
+++ b/reference/common_errors.rst
@@ -3,16 +3,6 @@ Common Error Messages
 
 .. _error_failed_execute:
 
-Relation *foo* is not distributed
----------------------------------
-
-This is caused by attempting to join local and distributed tables in the same query.
-
-Resolution
-~~~~~~~~~~
-
-For an example, with workarounds, see :ref:`join_local_dist` and :ref:`join_local_ref`.
-
 Could not receive query results
 -------------------------------
 
@@ -143,10 +133,20 @@ Resolution
 
 Try connecting directly to the server with psql to ensure it is running and accepting connections.
 
+Relation *foo* is not distributed
+---------------------------------
+
+This error no longer occurs in the current version of Citus. It was caused by attempting to join local and distributed tables in the same query.
+
+Resolution
+~~~~~~~~~~
+
+:ref:`Upgrade <upgrading>` to Citus 10.0 or higher.
+
 Unsupported clause type
 -----------------------
 
-This error no longer occurs in the current version of citus. It used to happen when executing a join with an inequality condition:
+This error no longer occurs in the current version of Citus. It used to happen when executing a join with an inequality condition:
 
 .. code-block:: postgresql
 
@@ -169,7 +169,7 @@ Resolution
 Cannot open new connections after the first modification command within a transaction
 -------------------------------------------------------------------------------------
 
-This error no longer occurs in the current version of citus except in certain unusual shard repair scenarios. It used to happen when updating rows in a transaction, and then running another command which would open new coordinator-to-worker connections.
+This error no longer occurs in the current version of Citus except in certain unusual shard repair scenarios. It used to happen when updating rows in a transaction, and then running another command which would open new coordinator-to-worker connections.
 
 .. code-block:: postgresql
 

--- a/reference/common_errors.rst
+++ b/reference/common_errors.rst
@@ -24,9 +24,10 @@ Caused when the the coordinator node is unable to connect to a worker.
 
 ::
 
-  WARNING:  connection error: ec2-52-21-20-100.compute-1.amazonaws.com:5432
-  DETAIL:  no connection to the server
-  ERROR:  could not receive query results
+  ERROR:  connection to the remote node localhost:5432 failed with the following error: could not connect to server: Connection refused
+          Is the server running on host "localhost" (127.0.0.1) and accepting
+          TCP/IP connections on port 5432?
+
 
 Resolution
 ~~~~~~~~~~
@@ -58,8 +59,7 @@ We can see this in action by distributing rows across worker nodes, and then run
 
 ::
 
-  ERROR:  40P01: canceling the transaction since it was involved in a distributed deadlock
-  LOCATION:  ProcessInterrupts, postgres.c:2988
+  ERROR:  canceling the transaction since it was involved in a distributed deadlock
 
 Resolution
 ~~~~~~~~~~
@@ -113,9 +113,8 @@ When all available worker connection slots are in use, further connections will 
 
 ::
 
-  WARNING:  08006: connection error: hostname:5432
+  WARNING:  connection error: hostname:5432
   ERROR:  could not connect to any active placements
-  DETAIL:  FATAL:  sorry, too many clients already
 
 Resolution
 ~~~~~~~~~~
@@ -204,9 +203,7 @@ Trying to make a unique index on a non-distribution column will generate an erro
 
 ::
 
-  ERROR:  0A000: cannot create constraint on "foo"
-  DETAIL:  Distributed relations cannot have UNIQUE, EXCLUDE, or PRIMARY KEY constraints that do not include the partition column (with an equality operator if EXCLUDE).
-  LOCATION:  ErrorIfUnsupportedConstraint, multi_utility.c:2505
+  ERROR:  creating unique indexes on non-partition columns is currently unsupported
 
 Enforcing uniqueness on a non-distribution column would require Citus to check every shard on every INSERT to validate, which defeats the goal of scalability.
 
@@ -225,7 +222,7 @@ Function create_distributed_table does not exist
 
   SELECT create_distributed_table('foo', 'id');
   /*
-  ERROR:  42883: function create_distributed_table(unknown, unknown) does not exist
+  ERROR:  function create_distributed_table(unknown, unknown) does not exist
   LINE 1: SELECT create_distributed_table('foo', 'id');
   HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
   */
@@ -255,7 +252,7 @@ Citus forbids running distributed queries that filter results using stable funct
 
 ::
 
-  ERROR:  0A000: STABLE functions used in UPDATE queries cannot be called with column references
+  ERROR:  STABLE functions used in UPDATE queries cannot be called with column references
 
 In this case the comparison operator ``<`` between timestamp and timestamptz is not immutable.
 

--- a/reference/common_errors.rst
+++ b/reference/common_errors.rst
@@ -24,7 +24,7 @@ Resolution
 
 To fix, check that the worker is accepting connections, and that DNS is correctly resolving.
 
-Cancelling the transaction since it was involved in a distributed deadlock
+Canceling the transaction since it was involved in a distributed deadlock
 -------------------------------------------------------------------------
 
 Deadlocks can happen not only in a single-node database, but in a distributed database, caused by queries executing across multiple nodes. Citus has the intelligence to recognize distributed deadlocks and defuse them by aborting one of the queries involved.

--- a/sharding/data_modeling.rst
+++ b/sharding/data_modeling.rst
@@ -73,7 +73,7 @@ Timeseries Data
 
 In a time-series workload, applications query recent information while archiving old information.
 
-The most common mistake in modeling timeseries information in Citus is using the timestamp itself as a distribution column. A hash distribution based on time will distribute times seemingly at random into different shards rather than keeping ranges of time together in shards. However queries involving time generally reference ranges of time (for example the most recent data), so such a hash distribution would lead to network overhead.
+The most common mistake in modeling timeseries information in Citus is using the timestamp itself as a distribution column. A hash distribution based on time will distribute times seemingly at random into different shards rather than keeping ranges of time together in shards. However, queries involving time generally reference ranges of time (for example the most recent data), so such a hash distribution would lead to network overhead.
 
 Best Practices
 ^^^^^^^^^^^^^^

--- a/use_cases/multi_tenant.rst
+++ b/use_cases/multi_tenant.rst
@@ -11,7 +11,7 @@ Multi-tenant Applications
 
 If you're building a Software-as-a-service (SaaS) application, you probably already have the notion of tenancy built into your data model. Typically, most information relates to tenants / customers / accounts and the database tables capture this natural relation.
 
-For SaaS applications, each tenant's data can be stored together in a single database instance and kept isolated from and invisible to other tenants. This is efficient in three ways. First application improvements apply to all clients. Second, sharing a database between tenants uses hardware efficiently. Last, it is much simpler to manage a single database for all tenants than a different database server for each tenant.
+For SaaS applications, each tenant's data can be stored together in a single database instance and kept isolated from and invisible to other tenants. This is efficient in three ways. First, application improvements apply to all clients. Second, sharing a database between tenants uses hardware efficiently. Last, it is much simpler to manage a single database for all tenants than a different database server for each tenant.
 
 However, a single relational database instance has traditionally had trouble scaling to the volume of data needed for a large multi-tenant application. Developers were forced to relinquish the benefits of the relational model when data exceeded the capacity of a single database node.
 
@@ -22,7 +22,7 @@ This guide takes a sample multi-tenant application and describes how to model it
 Let's Make an App – Ad Analytics
 --------------------------------
 
-We'll build the back-end for an application that tracks online advertising performance and provides an analytics dashboard on top. It's a natural fit for a multi-tenant application because user requests for data concern one (their own) company at a time. Code for the full example application is `available <https://github.com/citusdata/citus-example-ad-analytics>`_ on Github.
+We'll build the back-end for an application that tracks online advertising performance and provides an analytics dashboard on top. It's a natural fit for a multi-tenant application because user requests for data concern one company (their own) at a time. Code for the full example application is `available <https://github.com/citusdata/citus-example-ad-analytics>`_ on Github.
 
 Let's start by considering a simplified schema for this application. The application must keep track of multiple companies, each of which runs advertising campaigns. Campaigns have many ads, and each ad has associated records of its clicks and impressions.
 
@@ -380,7 +380,7 @@ For a fuller explanation of how DDL commands propagate through the cluster, see 
 When Data Differs Across Tenants
 --------------------------------
 
-Given that all tenants share a common schema and hardware infrastructure, how can we accommodate tenants which want to store information not needed by others? For example, one of the tenant applications using our advertising database may want to store tracking cookie information with clicks, whereas another tenant may care about browser agents. Traditionally databases using a shared schema approach for multi-tenancy have resorted to creating a fixed number of pre-allocated "custom" columns, or having external "extension tables." However PostgreSQL provides a much easier way with its unstructured column types, notably `JSONB <https://www.postgresql.org/docs/current/static/datatype-json.html>`_.
+Given that all tenants share a common schema and hardware infrastructure, how can we accommodate tenants which want to store information not needed by others? For example, one of the tenant applications using our advertising database may want to store tracking cookie information with clicks, whereas another tenant may care about browser agents. Traditionally databases using a shared schema approach for multi-tenancy have resorted to creating a fixed number of pre-allocated "custom" columns, or having external "extension tables." However, PostgreSQL provides a much easier way with its unstructured column types, notably `JSONB <https://www.postgresql.org/docs/current/static/datatype-json.html>`_.
 
 Notice that our schema already has a JSONB field in :code:`clicks` called :code:`user_data`. Each tenant can use it for flexible storage.
 
@@ -428,9 +428,9 @@ Being able to rebalance data in the Citus cluster allows you to grow your data s
 
 Also, if data increases for only a few large tenants, then you can isolate those particular tenants to separate nodes for better performance. (Tenant isolation is a feature of Citus Enterprise edition.)
 
-To scale out your Citus cluster, first add a new worker node to it. On Azure Database for PostgreSQL - Hyperscale (Citus), you can use the Azure Portal to add the required number of nodes. Alternately, if you run your own Citus installation, you can add nodes manually with the :ref:`citus_add_node` UDF.
+To scale out your Citus cluster, first add a new worker node to it. On Azure Database for PostgreSQL - Hyperscale (Citus), you can use the Azure Portal to add the required number of nodes. Alternatively, if you run your own Citus installation, you can add nodes manually with the :ref:`citus_add_node` UDF.
 
-Once you add the node it will be available in the system. However at this point no tenants are stored on it and Citus will not yet run any queries there. To move your existing data, you can ask Citus to rebalance the data. This operation moves bundles of rows called shards between the currently active nodes to attempt to equalize the amount of data on each node.
+Once you add the node it will be available in the system. However, at this point no tenants are stored on it and Citus will not yet run any queries there. To move your existing data, you can ask Citus to rebalance the data. This operation moves bundles of rows called shards between the currently active nodes to attempt to equalize the amount of data on each node.
 
 .. code-block:: postgres
 

--- a/use_cases/realtime_analytics.rst
+++ b/use_cases/realtime_analytics.rst
@@ -209,7 +209,7 @@ The following function wraps the rollup query up for convenience.
 
     * * * * * psql -c 'SELECT rollup_http_request();'
 
-  Alternately, an extension such as `pg_cron <https://github.com/citusdata/pg_cron>`_
+  Alternatively, an extension such as `pg_cron <https://github.com/citusdata/pg_cron>`_
   allows you to schedule recurring queries directly from the database.
 
 The dashboard query from earlier is now a lot nicer:
@@ -252,7 +252,7 @@ Approximate Distinct Counts
 A common question in HTTP analytics deals with :ref:`approximate distinct counts
 <count_distinct>`: How many unique visitors visited your site over the last month?
 Answering this question *exactly* requires storing the list of all previously-seen visitors
-in the rollup tables, a prohibitively large amount of data. However an approximate answer
+in the rollup tables, a prohibitively large amount of data. However, an approximate answer
 is much more manageable.
 
 A datatype called hyperloglog, or HLL, can answer the query
@@ -365,8 +365,8 @@ Next, include it in the rollups by modifying the rollup function:
       site_id,
       minute,
       COUNT(1) as request_count,
-      SUM(CASE WHEN (status_code between 200 and 299) THEN 1 ELSE 0 END) as success_c
-      SUM(CASE WHEN (status_code between 200 and 299) THEN 0 ELSE 1 END) as error_cou
+      SUM(CASE WHEN (status_code between 200 and 299) THEN 1 ELSE 0 END) as success_count
+      SUM(CASE WHEN (status_code between 200 and 299) THEN 0 ELSE 1 END) as error_count
       SUM(response_time_msec) / COUNT(1) AS average_response_time_msec
   - FROM http_request
   +   , jsonb_object_agg(request_country, country_count) AS country_counters

--- a/use_cases/timeseries.rst
+++ b/use_cases/timeseries.rst
@@ -27,7 +27,7 @@ Time-based partitioning makes most sense when:
 1. Most queries access a very small subset of the most recent data
 2. Older data is periodically expired (deleted/dropped)
 
-Keep in mind that, in the wrong situation, reading all these partitions can hurt overhead more than it helps. However in the right situations it is quite helpful. For example, when keeping a year of time series data and regularly querying only the most recent week.
+Keep in mind that, in the wrong situation, reading all these partitions can hurt overhead more than it helps. However, in the right situations it is quite helpful. For example, when keeping a year of time series data and regularly querying only the most recent week.
 
 Scaling Timeseries Data on Citus
 --------------------------------
@@ -166,7 +166,7 @@ Now whenever maintenance runs, partitions older than a month are automatically d
 Archiving with Columnar Storage
 -------------------------------
 
-Some applications have data logically divides into a small updatable part and a
+Some applications have data logically divided into a small updatable part and a
 larger part that's "frozen." Examples include logs, clickstreams, or sales
 records. In this case we can combine partitioning with :ref:`columnar table
 storage <columnar>` (introduced in Citus 10) to compress historical partitions
@@ -194,13 +194,13 @@ aspect, we won't distribute this table.
   -- columnar partitions for historical data
   CREATE TABLE ge0 PARTITION OF github.columnar_events
     FOR VALUES FROM ('2015-01-01 00:00:00') TO ('2015-01-01 02:00:00')
-    USING COLUMNAR;
+    USING columnar;
   CREATE TABLE ge1 PARTITION OF github.columnar_events
     FOR VALUES FROM ('2015-01-01 02:00:00') TO ('2015-01-01 04:00:00')
-    USING COLUMNAR;
+    USING columnar;
   CREATE TABLE ge2 PARTITION OF github.columnar_events
     FOR VALUES FROM ('2015-01-01 04:00:00') TO ('2015-01-01 06:00:00')
-    USING COLUMNAR;
+    USING columnar;
 
   -- row partition for latest data
   CREATE TABLE ge3 PARTITION OF github.columnar_events
@@ -293,7 +293,7 @@ In code, here's how to turn ge3 columnar:
   --   LOCK TABLE github.columnar_events IN ACCESS EXCLUSIVE MODE;
   
   LOCK TABLE ge3 IN EXCLUSIVE MODE;
-  CREATE TABLE ge3_tmp_new(LIKE ge3) USING COLUMNAR;
+  CREATE TABLE ge3_tmp_new(LIKE ge3) USING columnar;
   INSERT INTO ge3_tmp_new SELECT * FROM ge3;
   
   -- DETACH will take ACCESS EXCLUSIVE LOCK on the partitioned table

--- a/use_cases/timeseries.rst
+++ b/use_cases/timeseries.rst
@@ -264,10 +264,9 @@ queried in its entirety like a normal table.
 
 ::
 
-  .
    count
   -------
-   16001
+   13306
 
 Entries can be updated or deleted, as long as there's a WHERE clause on the
 partition key which filters entirely into row table partitions.

--- a/use_cases/timeseries.rst
+++ b/use_cases/timeseries.rst
@@ -102,7 +102,7 @@ Running ``\d+ github.events`` will now show more partitions:
 ::
 
   \d+ github.events
-                                                  Table "github.events"
+                                          Partitioned table "github.events"
       Column    |            Type             | Collation | Nullable | Default | Storage  | Stats target | Description
   --------------+-----------------------------+-----------+----------+---------+----------+--------------+-------------
    event_id     | bigint                      |           |          |         | plain    |              |
@@ -115,18 +115,19 @@ Running ``\d+ github.events`` will now show more partitions:
    org          | jsonb                       |           |          |         | extended |              |
    created_at   | timestamp without time zone |           |          |         | plain    |              |
   Partition key: RANGE (created_at)
-  Partitions: github.events_p2018_01_15_0700 FOR VALUES FROM ('2018-01-15 07:00:00') TO ('2018-01-15 08:00:00'),
-              github.events_p2018_01_15_0800 FOR VALUES FROM ('2018-01-15 08:00:00') TO ('2018-01-15 09:00:00'),
-              github.events_p2018_01_15_0900 FOR VALUES FROM ('2018-01-15 09:00:00') TO ('2018-01-15 10:00:00'),
-              github.events_p2018_01_15_1000 FOR VALUES FROM ('2018-01-15 10:00:00') TO ('2018-01-15 11:00:00'),
-              github.events_p2018_01_15_1100 FOR VALUES FROM ('2018-01-15 11:00:00') TO ('2018-01-15 12:00:00'),
-              github.events_p2018_01_15_1200 FOR VALUES FROM ('2018-01-15 12:00:00') TO ('2018-01-15 13:00:00'),
-              github.events_p2018_01_15_1300 FOR VALUES FROM ('2018-01-15 13:00:00') TO ('2018-01-15 14:00:00'),
-              github.events_p2018_01_15_1400 FOR VALUES FROM ('2018-01-15 14:00:00') TO ('2018-01-15 15:00:00'),
-              github.events_p2018_01_15_1500 FOR VALUES FROM ('2018-01-15 15:00:00') TO ('2018-01-15 16:00:00')
+  Partitions: github.events_p2021_02_03_1300 FOR VALUES FROM ('2021-02-03 13:00:00') TO ('2021-02-03 14:00:00'),
+              github.events_p2021_02_03_1400 FOR VALUES FROM ('2021-02-03 14:00:00') TO ('2021-02-03 15:00:00'),
+              github.events_p2021_02_03_1500 FOR VALUES FROM ('2021-02-03 15:00:00') TO ('2021-02-03 16:00:00'),
+              github.events_p2021_02_03_1600 FOR VALUES FROM ('2021-02-03 16:00:00') TO ('2021-02-03 17:00:00'),
+              github.events_p2021_02_03_1700 FOR VALUES FROM ('2021-02-03 17:00:00') TO ('2021-02-03 18:00:00'),
+              github.events_p2021_02_03_1800 FOR VALUES FROM ('2021-02-03 18:00:00') TO ('2021-02-03 19:00:00'),
+              github.events_p2021_02_03_1900 FOR VALUES FROM ('2021-02-03 19:00:00') TO ('2021-02-03 20:00:00'),
+              github.events_p2021_02_03_2000 FOR VALUES FROM ('2021-02-03 20:00:00') TO ('2021-02-03 21:00:00'),
+              github.events_p2021_02_03_2100 FOR VALUES FROM ('2021-02-03 21:00:00') TO ('2021-02-03 22:00:00'),
+              github.events_default DEFAULT
 
 
-By default ``create_parent`` creates four partitions in the past, four in the future, and one for the present, all based on system time. If you need to backfill older data, you can specify a ``p_start_partition`` parameter in the call to ``create_parent``, or ``p_premake`` to make partitions for the future. See the `pg_partman documentation <https://github.com/keithf4/pg_partman/blob/master/doc/pg_partman.md>`_ for details.
+By default ``create_parent`` creates four partitions in the past, four in the future, and one for the present, all based on system time. If you need to backfill older data, you can specify a ``p_start_partition`` parameter in the call to ``create_parent``, or ``p_premake`` to make partitions for the future. For PostgreSQL 11 or above, a default partition is automatically created. A "_default" suffix is added onto the current table name. See the `pg_partman documentation <https://github.com/keithf4/pg_partman/blob/master/doc/pg_partman.md>`_ for details.
 
 As time progresses, pg_partman will need to do some maintenance to create new partitions and drop old ones. Anytime you want to trigger maintenance, call:
 

--- a/use_cases/timeseries.rst
+++ b/use_cases/timeseries.rst
@@ -167,7 +167,7 @@ Now whenever maintenance runs, partitions older than a month are automatically d
 Archiving with Columnar Storage
 -------------------------------
 
-Some applications have data logically divided into a small updatable part and a
+Some applications have data that logically divides into a small updatable part and a
 larger part that's "frozen." Examples include logs, clickstreams, or sales
 records. In this case we can combine partitioning with :ref:`columnar table
 storage <columnar>` (introduced in Citus 10) to compress historical partitions
@@ -264,6 +264,7 @@ queried in its entirety like a normal table.
 
 ::
 
+  .
    count
   -------
    13306

--- a/use_cases/timeseries.rst
+++ b/use_cases/timeseries.rst
@@ -214,7 +214,7 @@ Next, download sample data:
   wget http://examples.citusdata.com/github_archive/github_events-2015-01-01-{0..5}.csv.gz
   gzip -d github_events-2015-01-01-*.gz
 
-And load it:
+And load it (note that this data requires the database to have UTF8 encoding):
 
 .. code-block:: psql
 


### PR DESCRIPTION
DESCRIPTION: Docs updates after release testing for Citus 10.0

I tested the _Use-Case Guides_, _Administer_ and _Troubleshoot_ sections. 
(I went out of these sections only for the `However` to `However,` changes, with a find-replace in the whole repo)

Mainly some outdated outputs, partitioned table description, some small typos.

I also put the UTF8 encoding warning since I experienced issues with my database setup because it had SQL_ASCII encoding.