### PR TITLE
Remove COPY limitation from max_shared_pool_size

### DIFF
--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -384,10 +384,10 @@ the note below). The value -1 disables throttling.
 .. note::
 
   There are certain operations that do not obey citus.max_shared_pool_size,
-  most importantly COPY and repartition joins. That's why it can be prudent to
-  increase the max_connections on the workers a bit higher than max_connections
-  on the coordinator. This gives extra space for connections required for COPY
-  and repartition queries on the workers.
+  most importantly repartition joins. That's why it can be prudent to increase
+  the max_connections on the workers a bit higher than max_connections
+  on the coordinator. This gives extra space for connections required for
+  repartition queries on the workers.
 
 citus.max_adaptive_executor_pool_size (integer)
 ***********************************************


### PR DESCRIPTION
As of Citus 9.5, COPY also honors `citus.max_shared_pool_size` via https://github.com/citusdata/citus/pull/4034. This PR reflects the change on the docs.