### PR TITLE
Preserve keyboard focus on menu item during navigation

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -145,6 +145,9 @@
         // "slideDown" means "show," it's not a direction of movement
         $("#consentBox").slideDown("linear");
       }
+
+      // move keyboard focus to selected menu item
+      $('li.toctree-l1 a.current').focus();
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
The downside is that it moves focus away from "Skip to main content."