### PR TITLE
Removes upgrade_to_reference_table UDF

### DIFF
--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -247,7 +247,7 @@ You can defer reference table replication by setting the
 ``citus.replicate_reference_tables_on_activate`` GUC to 'off'. Reference table
 replication will then happen when we create new shards on the node. For instance,
 when calling :ref:`create_distributed_table`, :ref:`create_reference_table`,
- or when the shard rebalancer moves shards to the new node.
+or when the shard rebalancer moves shards to the new node.
 
 The default value for this GUC is 'on'.
 

--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -247,8 +247,7 @@ You can defer reference table replication by setting the
 ``citus.replicate_reference_tables_on_activate`` GUC to 'off'. Reference table
 replication will then happen when we create new shards on the node. For instance,
 when calling :ref:`create_distributed_table`, :ref:`create_reference_table`,
-:ref:`upgrade_to_reference_table`, or when the shard rebalancer moves shards to
-the new node.
+ or when the shard rebalancer moves shards to the new node.
 
 The default value for this GUC is 'on'.
 

--- a/develop/api_udf.rst
+++ b/develop/api_udf.rst
@@ -266,33 +266,6 @@ reference table
 
 	SELECT create_reference_table('nation');
 
-.. _upgrade_to_reference_table:
-
-upgrade_to_reference_table
-$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-
-The upgrade_to_reference_table() function takes an existing distributed table which has a shard count of one, and upgrades it to be a recognized reference table. After calling this function, the table will be as if it had been created with :ref:`create_reference_table <create_reference_table>`.
-
-Arguments
-************************
-
-**table_name:** Name of the distributed table (having shard count = 1) which will be distributed as a reference table.
-
-Return Value
-********************************
-
-N/A
-
-Example
-*************************
-
-This example informs the database that the nation table should be defined as a
-reference table
-
-.. code-block:: postgresql
-
-	SELECT upgrade_to_reference_table('nation');
-
 .. _mark_tables_colocated:
 
 mark_tables_colocated

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -79,12 +79,6 @@ Now queries such as one calculating tax for a shopping cart can join on the :cod
 
 In addition to distributing a table as a single replicated shard, the :code:`create_reference_table` UDF marks it as a reference table in the Citus metadata tables. Citus automatically performs two-phase commits (`2PC <https://en.wikipedia.org/wiki/Two-phase_commit_protocol>`_) for modifications to tables marked this way, which provides strong consistency guarantees.
 
-If you have an existing distributed table which has a shard count of one, you can upgrade it to be a recognized reference table by running
-
-.. code-block:: postgresql
-
-  SELECT upgrade_to_reference_table('table_name');
-
 For another example of using reference tables in a multi-tenant application, see :ref:`mt_ref_tables`.
 
 Distributing Coordinator Data

--- a/develop/reference_ddl.rst
+++ b/develop/reference_ddl.rst
@@ -79,6 +79,14 @@ Now queries such as one calculating tax for a shopping cart can join on the :cod
 
 In addition to distributing a table as a single replicated shard, the :code:`create_reference_table` UDF marks it as a reference table in the Citus metadata tables. Citus automatically performs two-phase commits (`2PC <https://en.wikipedia.org/wiki/Two-phase_commit_protocol>`_) for modifications to tables marked this way, which provides strong consistency guarantees.
 
+If you have an existing distributed table, you can change it to
+a reference table by running:
+
+.. code-block:: postgresql
+
+   SELECT undistribute_table('table_name');
+   SELECT create_reference_table('table_name');
+
 For another example of using reference tables in a multi-tenant application, see :ref:`mt_ref_tables`.
 
 Distributing Coordinator Data


### PR DESCRIPTION
We removed the `upgrade_to_reference_table` in citus v10.0.0 but left it in the docs