### PR TITLE
Make clear that in PG14 we encode things as binary by default

### DIFF
--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -345,11 +345,12 @@ This parameter can be set at run-time and is effective on the coordinator.
 Intermediate Data Transfer
 -------------------------------------------------------------------
 
+.. _binary_worker_copy_format:
+
 citus.binary_worker_copy_format (boolean)
-$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-Use the binary copy format to transfer intermediate data between workers. During large table joins, Citus may have to dynamically repartition and shuffle data between different workers. For Postgres 13 and lower the default for this setting is ``false``, which means text encodig is used to transfer this data. For Postgres 14 and higher, the default is ``true``. When this parameter is ``true`` the database is instructed to use PostgreSQL’s binary serialization format to transfer this data. This parameter is effective on the workers and needs to be changed in the postgresql.conf file. After editing the config file, users can send a SIGHUP signal or restart the server for this change to take effect.
-
+Use the binary copy format to transfer intermediate data between workers. During large table joins, Citus may have to dynamically repartition and shuffle data between different workers. For Postgres 13 and lower, the default for this setting is ``false``, which means text encoding is used to transfer this data. For Postgres 14 and higher, the default is ``true``. Setting this parameter is ``true`` instructs the database to use PostgreSQL’s binary serialization format to transfer data. The parameter is effective on the workers and needs to be changed in the postgresql.conf file. After editing the config file, users can send a SIGHUP signal or restart the server for this change to take effect.
 
 citus.max_intermediate_result_size (integer)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$

--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -348,7 +348,7 @@ Intermediate Data Transfer
 citus.binary_worker_copy_format (boolean)
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-Use the binary copy format to transfer intermediate data between workers. During large table joins, Citus may have to dynamically repartition and shuffle data between different workers. By default, this data is transferred in text format. Enabling this parameter instructs the database to use PostgreSQL’s binary serialization format to transfer this data. This parameter is effective on the workers and needs to be changed in the postgresql.conf file. After editing the config file, users can send a SIGHUP signal or restart the server for this change to take effect.
+Use the binary copy format to transfer intermediate data between workers. During large table joins, Citus may have to dynamically repartition and shuffle data between different workers. For Postgres 13 and lower the default for this setting is ``false``, which means text encodig is used to transfer this data. For Postgres 14 and higher, the default is ``true``. When this parameter is ``true`` the database is instructed to use PostgreSQL’s binary serialization format to transfer this data. This parameter is effective on the workers and needs to be changed in the postgresql.conf file. After editing the config file, users can send a SIGHUP signal or restart the server for this change to take effect.
 
 
 citus.max_intermediate_result_size (integer)
@@ -471,8 +471,9 @@ amounts of data.  Examples are when a lot of rows are requested, the rows have
 many columns, or they use big types such as ``hll`` from the postgresql-hll
 extension.
 
-The default value is false, which means all results are encoded and transferred
-in text format.
+The default value is ``true`` for Postgres versions 14 and higher. For Postgres
+versions 13 and lower the default is ``false``, which means all results are
+encoded and transferred in text format.
 
 .. _max_shared_pool_size:
 

--- a/performance/performance_tuning.rst
+++ b/performance/performance_tuning.rst
@@ -306,7 +306,7 @@ The **greedy** policy aims to distribute tasks evenly across the workers. This p
 Intermediate Data Transfer Format
 ------------------------------------------------
 
-Citus, by default on Postgres 13 and lower, transfers intermediate query data between workers in textual format. For certain data types like hll or hstore arrays, the cost of serializing and deserializing data is pretty high. In such cases, using binary format for transferring intermediate data can improve query performance. Enabling the ``citus.binary_worker_copy_format`` configuration option uses the binary format.
+On Postgres 13 and lower, Citus defaults to transfering intermediate query data between workers in textual format. For certain data types, like hll or hstore arrays, the cost of serializing and deserializing data can be high. In such cases, using the binary format to transfer intermediate data can improve query performance. You can enable the :ref:`binary_worker_copy_format` configuration option to use the binary format.
 
 Binary protocol
 ---------------

--- a/performance/performance_tuning.rst
+++ b/performance/performance_tuning.rst
@@ -306,9 +306,7 @@ The **greedy** policy aims to distribute tasks evenly across the workers. This p
 Intermediate Data Transfer Format
 ------------------------------------------------
 
-Citus, by default, transfers intermediate query data between workers in textual format. This is generally best, as text files typically have smaller sizes than the binary representation. A more compact representation leads to lower network and disk I/O while writing and transferring intermediate data.
-
-However, for certain data types like hll or hstore arrays, the cost of serializing and deserializing data is pretty high. In such cases, using binary format for transferring intermediate data can improve query performance. Enabling the citus.binary_worker_copy_format configuration option uses the binary format.
+Citus, by default on Postgres 13 and lower, transfers intermediate query data between workers in textual format. For certain data types like hll or hstore arrays, the cost of serializing and deserializing data is pretty high. In such cases, using binary format for transferring intermediate data can improve query performance. Enabling the ``citus.binary_worker_copy_format`` configuration option uses the binary format.
 
 Binary protocol
 ---------------
@@ -323,6 +321,9 @@ In those cases it can be beneficial to set ``citus.enable_binary_protocol`` to
 using text encoding. Binary encoding significantly reduces bandwidth for types
 that have a compact binary representation, such as ``hll``, ``tdigest``,
 ``timestamp`` and ``double precision``.
+
+For Postgres 14 and higher, the default for this setting is already ``true``.
+So explicitly enabling it for those Postgres versions has no effect.
 
 Adaptive Executor
 -----------------


### PR DESCRIPTION
In Citus 10.2 we fixed some bugs in binary result encoding and Postgres
fixed some bugs in PG14. So we decided to make binary encoding the
default for PG14. This updates the docs to say so.

It also removes a note about binary encoding resulting in more data.
This is true in some rare cases, but usually people binary encoding will
result in smaller data.