### PR TITLE
Add tcp_user_timeout to the list of allowed options for node_conninfo

### DIFF
--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -99,7 +99,7 @@ The ``citus.node_conninfo`` GUC sets non-sensitive `libpq connection parameters 
   SET citus.node_conninfo =
     'sslrootcert=/path/to/citus.crt sslmode=verify-full';
 
-Citus honors only a whitelisted subset of the options, namely:
+Citus honors only a specific subset of the allowed options, namely:
 
 * application_name
 * connect_timeout
@@ -113,6 +113,7 @@ Citus honors only a whitelisted subset of the options, namely:
 * sslcrl
 * sslmode  (defaults to "require" as of Citus 8.1)
 * sslrootcert
+* tcp_user_timeout
 
 *(† = subject to the runtime presence of optional PostgreSQL features)*
 


### PR DESCRIPTION
Since Citus 10.2 we also support `tcp_user_timeout` here. In passing
remove mention of whitelist, in an effort to not use possibly offensive
words.