### PR TITLE
Fix missing double quotes

### DIFF
--- a/installation/multi_node_debian.rst
+++ b/installation/multi_node_debian.rst
@@ -100,7 +100,7 @@ addresses) and server ports to the table.
   # to match the actual hostname
 
   sudo -i -u postgres psql -c \
-    "SELECT citus_set_coordinator_host('coord.example.com', 5432);
+    "SELECT citus_set_coordinator_host('coord.example.com', 5432);"
 
   # Add the worker nodes.
   #

--- a/installation/multi_node_rhel.rst
+++ b/installation/multi_node_rhel.rst
@@ -106,7 +106,7 @@ and server ports to the table.
   # to match the actual hostname
 
   sudo -i -u postgres psql -c \
-    "SELECT citus_set_coordinator_host('coord.example.com', 5432);
+    "SELECT citus_set_coordinator_host('coord.example.com', 5432);"
 
   # Add the worker nodes.
   #


### PR DESCRIPTION
Came across this while reading the docs. Just missing a double quote at the end of the line for multi-node installations.