### PR TITLE
Allow providing host parameter via citus.node_conninfo

### DIFF
--- a/develop/api_guc.rst
+++ b/develop/api_guc.rst
@@ -119,6 +119,7 @@ Citus honors only a specific subset of the allowed options, namely:
 * application_name
 * connect_timeout
 * gsslib†
+* host
 * keepalives
 * keepalives_count
 * keepalives_idle


### PR DESCRIPTION
See https://github.com/citusdata/citus/pull/7541.

Seems that we don't provide much explanation on the usages of those parameters, so skipped doing so.